### PR TITLE
Fix bug in executor and add quiver approval module

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -18,7 +18,7 @@ _total_invested_today = 0.0
 quiver_signals_log = {}
 
 def reset_daily_investment():
-    global _total_investment_day, _last_investment_day, executed_symbols_today
+    global _total_invested_today, _last_investment_day, executed_symbols_today
     today = datetime.utcnow().date()
     if today != _last_investment_day:
         _total_invested_today = 0.0

--- a/signals/quiver_approval.py
+++ b/signals/quiver_approval.py
@@ -1,0 +1,13 @@
+from .quiver_utils import (
+    is_approved_by_quiver,
+    evaluate_quiver_signals,
+    get_all_quiver_signals,
+    QUIVER_APPROVAL_THRESHOLD,
+)
+
+__all__ = [
+    "is_approved_by_quiver",
+    "evaluate_quiver_signals",
+    "get_all_quiver_signals",
+    "QUIVER_APPROVAL_THRESHOLD",
+]


### PR DESCRIPTION
## Summary
- correct typo in `reset_daily_investment`
- add `signals/quiver_approval.py` module to expose quiver helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', requests)*

------
https://chatgpt.com/codex/tasks/task_e_684dcf0a31848324a85d8634891572b6