### PR TITLE
Mask API key logging

### DIFF
--- a/signals/quiver_utils.py
+++ b/signals/quiver_utils.py
@@ -113,7 +113,11 @@ def evaluate_quiver_signals(signals, symbol=""):
 
 
 def safe_quiver_request(url, retries=3, delay=2):
-    print(f"🔑 Usando clave Quiver: {repr(QUIVER_API_KEY)}")  # 👈 LOG DE LA CLAVE
+    # Log only that the key is present without revealing it
+    if QUIVER_API_KEY:
+        print("🔑 Usando clave Quiver: [REDACTED]")
+    else:
+        print("🔑 Advertencia: QUIVER_API_KEY no configurada")
     for i in range(retries):
         try:
             r = throttled_request(requests.get, url, headers=HEADERS, timeout=15)

--- a/test_env.py
+++ b/test_env.py
@@ -3,4 +3,5 @@ import os
 from dotenv import load_dotenv
 
 load_dotenv()
-print("🔑 QUIVER_API_KEY =", os.getenv("QUIVER_API_KEY"))
+key_set = bool(os.getenv("QUIVER_API_KEY"))
+print("🔑 QUIVER_API_KEY is set" if key_set else "⚠️ QUIVER_API_KEY not set")


### PR DESCRIPTION
## Summary
- avoid logging Quiver API key in `safe_quiver_request`
- redact API key output in test environment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684eaf14db788324b23a5d57c4cc1b77