### PR TITLE
Fix email logging

### DIFF
--- a/utils/emailer.py
+++ b/utils/emailer.py
@@ -30,6 +30,6 @@ def send_email(subject, body, attach_log=False):
             server.login(EMAIL_SENDER, EMAIL_PASSWORD)
             server.sendmail(EMAIL_SENDER, EMAIL_RECEIVER, message.as_string())
 
-        print("📩 Correo enviado correctamente!")
+        log_event("📩 Correo enviado correctamente!")
     except Exception as e:
-        print(f"❌ Error enviando correo: {e}")
+        log_event(f"❌ Error enviando correo: {e}")


### PR DESCRIPTION
## Summary
- log `send_email` events instead of printing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68509935671c8324b9e9434fc0e9653f