### PR TITLE
Use mocks for Quiver API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Trading Bot
+
 Estructura modular del bot de trading.
+
+## Tests
+
+The unit tests are designed to run without network access.  External API calls
+to QuiverQuant and `yfinance` are replaced with mocked responses so the suite
+can be executed in isolated environments (e.g. CI) without real credentials.

--- a/test_env.py
+++ b/test_env.py
@@ -1,7 +1,24 @@
-# test_env.py
+"""Environment variable tests using mocked values.
+
+The project expects the ``QUIVER_API_KEY`` environment variable to be defined.
+In the CI environment we avoid relying on a real key by patching ``os.environ``
+so that loading the ``.env`` file never triggers network calls or requires
+secret values.
+"""
+
 import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# Provide dummy module when python-dotenv is missing
+sys.modules.setdefault("dotenv", SimpleNamespace(load_dotenv=lambda *a, **k: None))
 from dotenv import load_dotenv
 
-load_dotenv()
-key_set = bool(os.getenv("QUIVER_API_KEY"))
-print("🔑 QUIVER_API_KEY is set" if key_set else "⚠️ QUIVER_API_KEY not set")
+
+def test_quiver_api_key_loaded():
+    """Ensure ``QUIVER_API_KEY`` is read from the environment."""
+
+    with patch.dict(os.environ, {"QUIVER_API_KEY": "dummy"}, clear=True):
+        load_dotenv()
+        assert os.getenv("QUIVER_API_KEY") == "dummy"


### PR DESCRIPTION
## Summary
- replace live API calls in `tests/test_quiver_approval.py` with mocks
- mock environment variable loading in `test_env.py`
- document mocked behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685099350e1083248c35731f1103daf9