### PR TITLE
Add env flag to disable short scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ Estructura modular del bot de trading.
 The unit tests are designed to run without network access.  External API calls
 to QuiverQuant and `yfinance` are replaced with mocked responses so the suite
 can be executed in isolated environments (e.g. CI) without real credentials.
+
+## Configuration
+
+Short-selling features can be toggled via the `ENABLE_SHORTS` environment
+variable.  When unset or set to `false`, the scheduler will skip running the
+short scan and only log long opportunities driven by Quiver signals.

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -20,15 +20,18 @@ from utils.generate_symbols_csv import generate_symbols_csv
 from signals.filters import is_position_open
 
 
-from signals.quiver_utils import initialize_quiver_caches  # 👈 Añadido aquí
-initialize_quiver_caches()  # 👈 Llamada a la función antes de iniciar nada más
-
 import threading
 from datetime import datetime
 from pytz import timezone
 import os
 import pandas as pd
 import time as pytime
+
+from signals.quiver_utils import initialize_quiver_caches  # 👈 Añadido aquí
+initialize_quiver_caches()  # 👈 Llamada a la función antes de iniciar nada más
+
+# Flag to control short-selling features via environment variable
+ENABLE_SHORTS = os.getenv("ENABLE_SHORTS", "false").lower() == "true"
 
 
 
@@ -223,7 +226,10 @@ def start_schedulers():
     threading.Thread(target=monitor_open_positions, daemon=True).start()
     threading.Thread(target=pre_market_scan, daemon=True).start()
     threading.Thread(target=daily_summary, daemon=True).start()
-    threading.Thread(target=short_scan, daemon=True).start()
+    if ENABLE_SHORTS:
+        threading.Thread(target=short_scan, daemon=True).start()
+    else:
+        print("🔕 Short scanning disabled (ENABLE_SHORTS=False)", flush=True)
 
 
 

--- a/signals/quiver_approval.py
+++ b/signals/quiver_approval.py
@@ -1,9 +1,8 @@
-from .quiver_utils import (
-    is_approved_by_quiver,
-    evaluate_quiver_signals,
-    get_all_quiver_signals,
-    QUIVER_APPROVAL_THRESHOLD,
-)
+"""Convenient re-exports for Quiver utilities."""
+
+from . import quiver_utils as _quiver
+
+QUIVER_APPROVAL_THRESHOLD = _quiver.QUIVER_APPROVAL_THRESHOLD
 
 __all__ = [
     "is_approved_by_quiver",
@@ -11,3 +10,12 @@ __all__ = [
     "get_all_quiver_signals",
     "QUIVER_APPROVAL_THRESHOLD",
 ]
+
+
+def __getattr__(name):
+    """Delegate attribute access to ``quiver_utils``.
+
+    Using ``__getattr__`` allows test suites to patch objects on
+    ``signals.quiver_utils`` and have those patches reflected here.
+    """
+    return getattr(_quiver, name)


### PR DESCRIPTION
## Summary
- add `ENABLE_SHORTS` environment flag to toggle short-selling logic
- export Quiver utilities dynamically so tests can patch them
- document new setting in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517966ce088324ba2ebe8cd057d60f