### PR TITLE
Fix Quiver API tests

### DIFF
--- a/signals/quiver_approval.py
+++ b/signals/quiver_approval.py
@@ -12,10 +12,34 @@ __all__ = [
 ]
 
 
+def is_approved_by_quiver(symbol: str) -> bool:
+    """Proxy to :func:`quiver_utils.is_approved_by_quiver`.
+
+    Keeping this thin wrapper allows test suites to patch
+    ``signals.quiver_utils.is_approved_by_quiver`` and have those
+    patches reflected here regardless of import order.
+    """
+
+    return _quiver.is_approved_by_quiver(symbol)
+
+
+def evaluate_quiver_signals(signals: dict, symbol: str = "") -> bool:
+    """Proxy to :func:`quiver_utils.evaluate_quiver_signals`."""
+
+    return _quiver.evaluate_quiver_signals(signals, symbol)
+
+
+def get_all_quiver_signals(symbol: str) -> dict:
+    """Proxy to :func:`quiver_utils.get_all_quiver_signals`."""
+
+    return _quiver.get_all_quiver_signals(symbol)
+
+
 def __getattr__(name):
     """Delegate attribute access to ``quiver_utils``.
 
     Using ``__getattr__`` allows test suites to patch objects on
     ``signals.quiver_utils`` and have those patches reflected here.
     """
+
     return getattr(_quiver, name)


### PR DESCRIPTION
## Summary
- ensure Quiver helpers in `signals.quiver_approval` can be patched

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851cb2e9aa48324a625cadeb441fc82