### PR TITLE
Remove unused csv import

### DIFF
--- a/utils/generate_symbols_csv.py
+++ b/utils/generate_symbols_csv.py
@@ -4,7 +4,6 @@ import os
 import pandas as pd
 import alpaca_trade_api as tradeapi
 from dotenv import load_dotenv
-import csv
 
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- cleanup: remove unused csv import in generate_symbols_csv

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d9e0b6008324924dda9641253087