### PR TITLE
Add cached position helper

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -18,7 +18,7 @@ from utils.emailer import send_email
 from utils.logger import log_event
 from core.monitor import monitor_open_positions
 from utils.generate_symbols_csv import generate_symbols_csv
-from signals.filters import is_position_open
+from signals.filters import is_position_open, get_cached_positions
 
 
 import threading
@@ -67,6 +67,7 @@ def pre_market_scan():
                 print("🔁 Nuevo día detectado, reiniciando lista de símbolos.", flush=True)
 
             # Buscar el siguiente símbolo a evaluar
+            get_cached_positions(refresh=True)
             for symbol in stock_assets:
                 if symbol in evaluated_symbols_today or is_position_open(symbol):
                     continue

--- a/signals/reader.py
+++ b/signals/reader.py
@@ -2,7 +2,11 @@
 
 
 import pandas as pd
-from signals.filters import is_position_open, is_approved_by_finnhub_and_alphavantage
+from signals.filters import (
+    is_position_open,
+    is_approved_by_finnhub_and_alphavantage,
+    get_cached_positions,
+)
 from signals.quiver_utils import get_all_quiver_signals, score_quiver_signals, QUIVER_APPROVAL_THRESHOLD
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from broker.alpaca import api
@@ -106,6 +110,9 @@ def get_top_signals(verbose=False):
             last_reset_date = today
             print("🔁 Reiniciando símbolos evaluados: nuevo día detectado")
 
+        # Refresh positions cache once per cycle
+        get_cached_positions(refresh=True)
+
         symbols_to_evaluate = [
             s for s in stock_assets
             if s not in evaluated_symbols_today and not is_position_open(s)
@@ -137,6 +144,9 @@ def get_top_signals(verbose=False):
 def get_top_shorts(min_criteria=20, verbose=False):
     shorts = []
     already_considered = set()
+
+    # Refresh positions cache once before scanning
+    get_cached_positions(refresh=True)
 
     for symbol in stock_assets:
         if symbol in already_considered or is_position_open(symbol):


### PR DESCRIPTION
## Summary
- add a cached positions helper in `signals.filters`
- refresh the cache once per cycle in scanning loops
- update schedulers to use cached positions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bf9ad9748324aeedf4c7c717c281