### PR TITLE
Add retry options to Alpaca client

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ can be executed in isolated environments (e.g. CI) without real credentials.
 Short-selling features can be toggled via the `ENABLE_SHORTS` environment
 variable.  When unset or set to `false`, the scheduler will skip running the
 short scan and only log long opportunities driven by Quiver signals.
+
+Alpaca requests are made using a basic retry policy defined in
+`broker/alpaca.py`.  By default the client retries failed calls up to three
+times with an exponential backoff of three seconds.  You can modify the
+`Retry` options in that module if a different strategy is required.

--- a/broker/alpaca.py
+++ b/broker/alpaca.py
@@ -1,5 +1,6 @@
 import os
 import alpaca_trade_api as tradeapi
+from urllib3.util.retry import Retry
 from dotenv import load_dotenv
 from utils.logger import log_event  
 
@@ -9,7 +10,8 @@ api = tradeapi.REST(
     os.getenv("APCA_API_KEY_ID"),
     os.getenv("APCA_API_SECRET_KEY"),
     "https://paper-api.alpaca.markets",
-    api_version='v2'
+    api_version='v2',
+    retry_options=Retry(total=3, backoff_factor=3)
 )
 
 def is_market_open():


### PR DESCRIPTION
## Summary
- add retry policy support for Alpaca client
- document API retry behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bf9be4488324b4ec6483b9e9ebef