### PR TITLE
Fix Alpaca REST initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ variable.  When unset or set to `false`, the scheduler will skip running the
 short scan and only log long opportunities driven by Quiver signals.
 
 Alpaca requests are made using a basic retry policy defined in
-`broker/alpaca.py`.  By default the client retries failed calls up to three
-times with an exponential backoff of three seconds.  You can modify the
-`Retry` options in that module if a different strategy is required.
+`broker/alpaca.py`. The underlying `requests` session retries failed calls up
+to three times with an exponential backoff of three seconds. You can modify the
+`Retry` settings in that module if a different strategy is required.

--- a/broker/alpaca.py
+++ b/broker/alpaca.py
@@ -1,6 +1,7 @@
 import os
 import alpaca_trade_api as tradeapi
 from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 from dotenv import load_dotenv
 from utils.logger import log_event  
 
@@ -10,9 +11,14 @@ api = tradeapi.REST(
     os.getenv("APCA_API_KEY_ID"),
     os.getenv("APCA_API_SECRET_KEY"),
     "https://paper-api.alpaca.markets",
-    api_version='v2',
-    retry_options=Retry(total=3, backoff_factor=3)
+    api_version="v2",
 )
+
+# Configure basic retry logic on the underlying HTTP session
+retry = Retry(total=3, backoff_factor=3)
+adapter = HTTPAdapter(max_retries=retry)
+api._session.mount("https://", adapter)
+api._session.mount("http://", adapter)
 
 def is_market_open():
     try:


### PR DESCRIPTION
## Summary
- configure retry policy on Alpaca REST session instead of using removed `retry_options`
- document retry logic in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c3b4842c8324b933ad79baf2b9e5