### PR TITLE
Remove unused high_conviction_active variable

### DIFF
--- a/signals/quiver_utils.py
+++ b/signals/quiver_utils.py
@@ -116,9 +116,8 @@ def evaluate_quiver_signals(signals, symbol=""):
 
     print(f"🧠 {symbol} → score: {score} (umbral: {QUIVER_APPROVAL_THRESHOLD}), señales activas: {active_signals_count}")
 
-    # High conviction signals are still computed but no longer mandatory
+    # High conviction signals maintained for reference
     HIGH_CONVICTION_SIGNALS = ["insider_buy_more_than_sell", "has_gov_contract"]
-    high_conviction_active = any(signals.get(sig, False) for sig in HIGH_CONVICTION_SIGNALS)
 
     # Less strict: require at least two active signals and a lower score
     aprobado_por_señales = (


### PR DESCRIPTION
## Summary
- remove unused `high_conviction_active` variable from Quiver evaluation
- update comment about high conviction signals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ccb328508324bdc4cb170c1ee5c1