### PR TITLE
Set absolute logging path

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,8 +1,10 @@
 import os
 from datetime import datetime
 
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+log_dir = os.path.join(PROJECT_ROOT, "logs")
+
 def log_event(message):
-    log_dir = "logs"
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, "events.log")
 


### PR DESCRIPTION
## Summary
- ensure `utils.logger` writes logs to a consistent directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b1b1bbe083249287a1bc77c31e5f