### PR TITLE
Support multiple top signals

### DIFF
--- a/signals/reader.py
+++ b/signals/reader.py
@@ -126,6 +126,7 @@ def get_top_signals(verbose=False):
         for s in symbols_to_evaluate:
             evaluated_symbols_today.add(s)
 
+        approved = []
         with ThreadPoolExecutor(max_workers=8) as executor:
             futures = {executor.submit(evaluate_symbol, sym): sym for sym in symbols_to_evaluate}
             for future in as_completed(futures):
@@ -136,7 +137,12 @@ def get_top_signals(verbose=False):
                     print(f"⚠️ Error en hilo para {sym}: {e}")
                     continue
                 if result:
-                    return [result]
+                    approved.append(result)
+                if len(approved) >= 5:
+                    break
+        if approved:
+            return approved
+
 
     return []
 

--- a/tests/test_get_top_signals.py
+++ b/tests/test_get_top_signals.py
@@ -1,0 +1,56 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# Provide dummy modules if external dependencies are missing
+sys.modules.setdefault(
+    "requests",
+    SimpleNamespace(get=lambda *a, **k: None, adapters=SimpleNamespace(HTTPAdapter=lambda *a, **k: None)),
+)
+sys.modules.setdefault("requests.adapters", SimpleNamespace(HTTPAdapter=lambda *a, **k: None))
+sys.modules.setdefault("dotenv", SimpleNamespace(load_dotenv=lambda *a, **k: None))
+sys.modules.setdefault(
+    "yfinance",
+    SimpleNamespace(Ticker=lambda *a, **k: SimpleNamespace(info={}, history=lambda *a, **k: SimpleNamespace())),
+)
+sys.modules.setdefault(
+    "alpaca_trade_api",
+    SimpleNamespace(
+        REST=lambda *a, **k: SimpleNamespace(
+            list_positions=lambda: [],
+            get_asset=lambda s: SimpleNamespace(shortable=True),
+            get_bars=lambda *a, **k: SimpleNamespace(df=SimpleNamespace(empty=True)),
+            get_clock=lambda: SimpleNamespace(is_open=True),
+            _session=SimpleNamespace(mount=lambda *a, **k: None),
+        )
+    ),
+)
+sys.modules.setdefault("urllib3", SimpleNamespace(util=SimpleNamespace(retry=SimpleNamespace(Retry=lambda *a, **k: None))))
+sys.modules.setdefault("urllib3.util", SimpleNamespace(retry=SimpleNamespace(Retry=lambda *a, **k: None)))
+sys.modules.setdefault("urllib3.util.retry", SimpleNamespace(Retry=lambda *a, **k: None))
+
+from signals import reader
+
+
+def make_signals(active=True):
+    return {"sig1": active, "sig2": active}
+
+
+def dummy_score(signals):
+    return 10 if all(signals.values()) else 0
+
+
+def test_get_top_signals_returns_max_five():
+    symbols = ["A", "B", "C", "D", "E", "F"]
+    with patch.object(reader, "stock_assets", symbols), \
+         patch.object(reader, "get_all_quiver_signals", side_effect=lambda s: make_signals(True)), \
+         patch.object(reader, "score_quiver_signals", side_effect=dummy_score), \
+         patch.object(reader, "is_position_open", return_value=False), \
+         patch.object(reader, "get_cached_positions"), \
+         patch.object(reader, "evaluated_symbols_today", set()), \
+         patch.object(reader, "last_reset_date", reader.datetime.now().date()):
+        results = reader.get_top_signals()
+
+    assert len(results) == 5
+    returned_symbols = {r[0] for r in results}
+    assert returned_symbols.issubset(set(symbols))


### PR DESCRIPTION
## Summary
- allow `get_top_signals` to return up to five approved symbols
- add unit test for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b665de1c8324bbfd8f44c15d840e