### PR TITLE
Improve order reliability and logging

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -90,9 +90,10 @@ def pre_market_scan():
                             continue
                         amount_usd = calculate_investment_amount(score)
                         log_event(f"🛒 Intentando comprar {symb} por {amount_usd} USD")
-                        place_order_with_trailing_stop(symb, amount_usd, 1.5)
-                        with pending_opportunities_lock:
-                            pending_opportunities.add(symb)
+                        success = place_order_with_trailing_stop(symb, amount_usd, 1.5)
+                        if success:
+                            with pending_opportunities_lock:
+                                pending_opportunities.add(symb)
                         pytime.sleep(1.5)  # Pequeña espera entre órdenes
 
 

--- a/signals/reader.py
+++ b/signals/reader.py
@@ -146,10 +146,8 @@ def get_top_signals(verbose=False):
                     continue
                 if result:
                     approved.append(result)
-                if len(approved) >= 5:
-                    break
         if approved:
-            return approved
+            return approved[:5]
 
 
     return []


### PR DESCRIPTION
## Summary
- enhance `wait_for_order_fill` with verbose status printing and longer timeout
- validate tradability and funds before submitting a buy order
- print detailed info before and after order submission
- return order success status and update scheduler accordingly
- remove break in `get_top_signals` loop to allow scanning all symbols

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab03fce0c8324bf047ae5d9d5d2e4