### PR TITLE
Attach events log in summary email

### DIFF
--- a/tests/test_emailer.py
+++ b/tests/test_emailer.py
@@ -1,0 +1,52 @@
+import os
+from email import message_from_string
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import importlib
+
+# Reload module to ensure patched env vars
+import utils.emailer as emailer
+
+
+def test_send_email_attaches_events_log(tmp_path, monkeypatch):
+    # Prepare dummy log file
+    log_dir = tmp_path
+    log_path = log_dir / "events.log"
+    content = "line1\nline2"
+    log_path.write_text(content)
+
+    # Patch emailer configuration
+    monkeypatch.setattr(emailer, "EMAIL_SENDER", "sender@example.com", raising=False)
+    monkeypatch.setattr(emailer, "EMAIL_RECEIVER", "receiver@example.com", raising=False)
+    monkeypatch.setattr(emailer, "EMAIL_PASSWORD", "pwd", raising=False)
+    monkeypatch.setattr(emailer, "log_dir", str(log_dir), raising=False)
+    monkeypatch.setattr(emailer, "log_event", lambda msg: None)
+
+    sent_messages = []
+
+    class DummyServer:
+        def login(self, *a, **k):
+            pass
+        def sendmail(self, sender, receiver, msg):
+            sent_messages.append(msg)
+
+    class DummySMTP:
+        def __init__(self, *a, **k):
+            pass
+        def __enter__(self):
+            return DummyServer()
+        def __exit__(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(emailer.smtplib, "SMTP_SSL", lambda *a, **k: DummySMTP())
+
+    emailer.send_email("subj", "body", attach_log=True)
+
+    assert sent_messages, "No email was sent"
+    msg = message_from_string(sent_messages[0])
+    attachments = [part for part in msg.walk() if part.get_content_disposition() == "attachment"]
+    assert len(attachments) == 1
+    attachment = attachments[0]
+    assert attachment.get_filename() == "events.log"
+    assert attachment.get_payload(decode=True).decode() == content

--- a/utils/emailer.py
+++ b/utils/emailer.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.application import MIMEApplication
-from utils.logger import log_event
+from utils.logger import log_event, log_dir
 
 load_dotenv()
 
@@ -20,11 +20,13 @@ def send_email(subject, body, attach_log=False):
         message["Subject"] = subject
         message.attach(MIMEText(body, "plain"))
 
-        if attach_log and os.path.exists("trading_log.txt"):
-            with open("trading_log.txt", "rb") as log_file:
-                part = MIMEApplication(log_file.read(), Name="trading_log.txt")
-                part['Content-Disposition'] = 'attachment; filename="trading_log.txt"'
-                message.attach(part)
+        if attach_log:
+            log_file_path = os.path.join(log_dir, "events.log")
+            if os.path.exists(log_file_path):
+                with open(log_file_path, "rb") as log_file:
+                    part = MIMEApplication(log_file.read(), Name="events.log")
+                    part['Content-Disposition'] = 'attachment; filename="events.log"'
+                    message.attach(part)
 
         with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
             server.login(EMAIL_SENDER, EMAIL_PASSWORD)


### PR DESCRIPTION
## Summary
- attach `logs/events.log` when sending emails
- ensure attachment uses `events.log` filename
- add test validating the log attachment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644f206e308324a91828d2aa44f8ff