### PR TITLE
Add log summary CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,18 @@ approaches for running coroutines from worker threads:
 1. Scheduling the coroutine on the main loop using
    `asyncio.run_coroutine_threadsafe`.
 2. Creating an independent event loop inside each thread.
+
+## Utilities
+
+`utils/log_summary.py` provides a small CLI to inspect `logs/events.log` for a given date.
+It prints how many orders succeeded, failed, shorts were executed and any errors logged.
+
+```bash
+$ python utils/log_summary.py --date 2024-06-01
+```
+
+Without arguments it defaults to the current day:
+
+```bash
+$ python utils/log_summary.py
+```

--- a/utils/log_summary.py
+++ b/utils/log_summary.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Summarize trading events for a given date."""
+
+import argparse
+from datetime import datetime, date
+import os
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LOG_FILE = os.path.join(PROJECT_ROOT, "logs", "events.log")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Summarize trading log events")
+    parser.add_argument(
+        "-d",
+        "--date",
+        default=date.today().isoformat(),
+        help="Date to summarize in YYYY-MM-DD format. Defaults to today.",
+    )
+    return parser.parse_args()
+
+
+def summarize(log_path: str, target_date: str) -> None:
+    success = 0
+    failures = 0
+    shorts = 0
+    errors = 0
+
+    if not os.path.exists(log_path):
+        print(f"No log file found at {log_path}")
+        return
+
+    with open(log_path, encoding="utf-8") as f:
+        for line in f:
+            if not line.startswith("["):
+                continue
+            try:
+                timestamp_str, msg = line.strip().split("]", 1)
+                timestamp_str = timestamp_str.lstrip("[")
+                ts_date = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S").date()
+            except Exception:
+                continue
+
+            if ts_date.isoformat() != target_date:
+                continue
+
+            if "Short y trailing buy" in msg:
+                shorts += 1
+            if "✅" in msg and (
+                "Orden enviada" in msg
+                or "Compra y trailing stop" in msg
+                or "Short y trailing buy" in msg
+            ):
+                success += 1
+            if "Falló la orden" in msg:
+                failures += 1
+            if any(k in msg for k in ["❌", "⚠️", "⛔", "Error"]):
+                errors += 1
+
+    print(f"📅 Summary for {target_date}")
+    print(f"✅ Successful orders: {success}")
+    print(f"❌ Failed orders: {failures}")
+    print(f"📉 Shorts executed: {shorts}")
+    print(f"⚠️ Errors: {errors}")
+
+
+def main() -> None:
+    args = parse_args()
+    summarize(LOG_FILE, args.date)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `utils/log_summary.py` to summarize daily trading logs
- document the new tool and provide basic usage examples in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644f2150008324973f7b87e6dc9e98