### PR TITLE
Add realized PnL stats to daily summary

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -17,7 +17,7 @@ from core.options_trader import run_options_strategy, get_options_log_and_reset
 from signals.reader import get_top_signals, get_top_shorts
 from broker.alpaca import api, is_market_open
 from utils.emailer import send_email
-from utils.logger import log_event
+from utils.logger import log_event, log_dir
 from core.monitor import monitor_open_positions
 from utils.generate_symbols_csv import generate_symbols_csv
 from signals.filters import is_position_open, get_cached_positions
@@ -29,6 +29,7 @@ from pytz import timezone
 import os
 import pandas as pd
 import time as pytime
+import re
 
 from signals.quiver_utils import initialize_quiver_caches  # 👈 Añadido aquí
 initialize_quiver_caches()  # 👈 Llamada a la función antes de iniciar nada más
@@ -147,6 +148,43 @@ def short_scan():
             log_event(f"🔻 Total invertido en este ciclo de shorts: {invested_today_usd():.2f} USD")
         pytime.sleep(300)
 
+
+def _parse_today_pnl(log_path: str):
+    """Parse today's realized PnL entries from ``pnl.log``."""
+    wins = 0
+    losses = 0
+    total = 0.0
+    today = datetime.utcnow().date()
+
+    if not os.path.exists(log_path):
+        return wins, losses, total
+
+    with open(log_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            # Attempt to parse optional leading timestamp in [YYYY-MM-DD HH:MM:SS]
+            if line.startswith("[") and "]" in line:
+                ts_str, remainder = line.split("]", 1)
+                ts_str = ts_str.lstrip("[")
+                try:
+                    if datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S").date() != today:
+                        continue
+                except Exception:
+                    remainder = line
+                line = remainder
+
+            match = re.search(r"(-?\d+(?:\.\d+)?)", line)
+            if match:
+                value = float(match.group(1))
+                total += value
+                if value >= 0:
+                    wins += 1
+                else:
+                    losses += 1
+
+    return wins, losses, total
+
 def daily_summary():
     print("🌀 daily_summary iniciado.", flush=True)
     while True:
@@ -205,6 +243,13 @@ def daily_summary():
             except Exception as e:
                 body += f"\n\n❌ Error obteniendo PnL: {e}"
 
+            # PnL realizado del día
+            pnl_path = os.path.join(log_dir, "pnl.log")
+            wins, losses, realized_total = _parse_today_pnl(pnl_path)
+            body += f"\n💵 PnL realizado: {realized_total:.2f} USD"
+            body += f"\n🏆 Operaciones ganadoras: {wins}"
+            body += f"\n💔 Operaciones perdedoras: {losses}"
+
             # Opciones
             options_log = get_options_log_and_reset()
             if options_log:
@@ -217,6 +262,10 @@ def daily_summary():
                 pending_opportunities.clear()
             with pending_trades_lock:
                 pending_trades.clear()
+            for fname in ("events.log", "pnl.log"):
+                path = os.path.join(log_dir, fname)
+                if os.path.exists(path):
+                    open(path, "w").close()
 
         pytime.sleep(3600)
 


### PR DESCRIPTION
## Summary
- extend scheduler to parse `pnl.log`
- append realized PnL and win/loss counts to daily email
- clear `events.log` and `pnl.log` after sending summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c4c435e188324ace8d823f9333c9a