### PR TITLE
Add CSV backtesting script

### DIFF
--- a/backtest_from_trades.py
+++ b/backtest_from_trades.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Analyze historical trades from a CSV file."""
+
+import argparse
+import csv
+import os
+from typing import Dict, List, Sequence, Tuple
+
+
+Trade = Dict[str, str]
+
+
+def read_trades(path: str) -> List[Trade]:
+    with open(path, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def analyze_trades(trades: Sequence[Trade]) -> Dict[str, object]:
+    total = len(trades)
+    pnl_values = [float(t.get("pnl_usd", 0)) for t in trades]
+    total_pnl = sum(pnl_values)
+    win_rate = (sum(p > 0 for p in pnl_values) / total * 100) if total else 0.0
+    average_pnl = (total_pnl / total) if total else 0.0
+
+    # Signals
+    signal_counts: Dict[str, int] = {}
+    signal_totals: Dict[str, float] = {}
+    for t in trades:
+        sig = t.get("signal", "")
+        pnl = float(t.get("pnl_usd", 0))
+        signal_counts[sig] = signal_counts.get(sig, 0) + 1
+        signal_totals[sig] = signal_totals.get(sig, 0.0) + pnl
+
+    signals_summary = [
+        {
+            "signal": sig,
+            "count": cnt,
+            "avg_pnl": signal_totals[sig] / cnt if cnt else 0.0,
+        }
+        for sig, cnt in sorted(signal_counts.items(), key=lambda kv: kv[1], reverse=True)
+    ]
+
+    # Drawdown calculation
+    cumulative = 0.0
+    peak = 0.0
+    max_dd = 0.0
+    for pnl in pnl_values:
+        cumulative += pnl
+        if cumulative > peak:
+            peak = cumulative
+        drawdown = peak - cumulative
+        if drawdown > max_dd:
+            max_dd = drawdown
+
+    # Symbols profitability
+    symbol_totals: Dict[str, float] = {}
+    for t in trades:
+        sym = t.get("symbol", "")
+        pnl = float(t.get("pnl_usd", 0))
+        symbol_totals[sym] = symbol_totals.get(sym, 0.0) + pnl
+    sorted_symbols_desc = sorted(symbol_totals.items(), key=lambda kv: kv[1], reverse=True)
+    top_symbols = sorted_symbols_desc[:5]
+    sorted_symbols_asc = sorted(symbol_totals.items(), key=lambda kv: kv[1])
+    bottom_symbols = sorted_symbols_asc[:5]
+
+    return {
+        "total_trades": total,
+        "total_pnl": total_pnl,
+        "win_rate": win_rate,
+        "average_pnl": average_pnl,
+        "signals_summary": signals_summary,
+        "max_drawdown": max_dd,
+        "top_symbols": top_symbols,
+        "bottom_symbols": bottom_symbols,
+    }
+
+
+def format_summary(stats: Dict[str, object]) -> str:
+    lines = [
+        f"Total de operaciones: {stats['total_trades']}",
+        f"PnL total: {stats['total_pnl']:.2f} USD",
+        f"Win rate: {stats['win_rate']:.2f}%",
+        f"PnL medio por operación: {stats['average_pnl']:.2f} USD",
+    ]
+    if stats["signals_summary"]:
+        lines.append("Señales más frecuentes y PnL medio:")
+        for entry in stats["signals_summary"]:
+            lines.append(
+                f" - {entry['signal']}: {entry['count']} ops, avg {entry['avg_pnl']:.2f}"
+            )
+    lines.append(f"Máximo drawdown: {stats['max_drawdown']:.2f} USD")
+    if stats["top_symbols"]:
+        lines.append("5 símbolos más rentables:")
+        for sym, pnl in stats["top_symbols"]:
+            lines.append(f" - {sym}: {pnl:.2f}")
+    if stats["bottom_symbols"]:
+        lines.append("5 símbolos menos rentables:")
+        for sym, pnl in stats["bottom_symbols"]:
+            lines.append(f" - {sym}: {pnl:.2f}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Backtest summary from trades.csv")
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="Save summary to data/backtest_summary.txt",
+    )
+    args = parser.parse_args()
+
+    csv_path = os.path.join("data", "trades.csv")
+    trades = read_trades(csv_path)
+    stats = analyze_trades(trades)
+    summary = format_summary(stats)
+    print(summary)
+
+    if args.save:
+        out_path = os.path.join("data", "backtest_summary.txt")
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backtest_from_trades.py
+++ b/tests/test_backtest_from_trades.py
@@ -1,0 +1,19 @@
+from backtest_from_trades import analyze_trades
+
+
+def test_analyze_trades_basic():
+    trades = [
+        {"symbol": "A", "signal": "s1", "pnl_usd": "10"},
+        {"symbol": "B", "signal": "s2", "pnl_usd": "-5"},
+        {"symbol": "A", "signal": "s1", "pnl_usd": "20"},
+        {"symbol": "C", "signal": "s1", "pnl_usd": "-10"},
+        {"symbol": "B", "signal": "s3", "pnl_usd": "5"},
+    ]
+    stats = analyze_trades(trades)
+    assert stats["total_trades"] == 5
+    assert stats["total_pnl"] == 20
+    assert round(stats["win_rate"], 2) == 60.0
+    assert stats["average_pnl"] == 4.0
+    assert round(stats["max_drawdown"], 2) == 10.0
+    assert stats["top_symbols"][0][0] == "A"
+    assert stats["bottom_symbols"][0][0] == "C"


### PR DESCRIPTION
## Summary
- create `backtest_from_trades.py` to generate trading stats from `data/trades.csv`
- include a unit test for trade analytics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a1e768fc883248fa5beae6db161a4