### PR TITLE
Add modular Telegram reporting

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -22,6 +22,7 @@ from broker.alpaca import api, is_market_open
 from utils.emailer import send_email
 from utils.backtest_report import generate_paper_summary
 from utils.logger import log_event, log_dir
+from utils.telegram_report import generate_cumulative_report
 from core.monitor import monitor_open_positions, watchdog_trailing_stop
 from utils.generate_symbols_csv import generate_symbols_csv
 from signals.filters import is_position_open, get_cached_positions
@@ -269,6 +270,10 @@ def daily_summary():
 
             # Envío y limpieza
             send_email(subject, body, attach_log=True)
+            try:
+                generate_cumulative_report()
+            except Exception:
+                log_event("❌ Fallo Telegram, sistema sigue OK")
             with pending_opportunities_lock:
                 pending_opportunities.clear()
             with pending_trades_lock:

--- a/utils/telegram_alert.py
+++ b/utils/telegram_alert.py
@@ -1,0 +1,43 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+
+def send_telegram_alert(message: str, verbose: bool = False) -> bool:
+    """Send a simple text message via Telegram.
+
+    Parameters
+    ----------
+    message: str
+        Text to send.
+    verbose: bool, optional
+        If True, prints debug information. Default is False.
+
+    Returns
+    -------
+    bool
+        True if the message was sent, False otherwise.
+    """
+    if not TELEGRAM_BOT_TOKEN or not TELEGRAM_CHAT_ID:
+        if verbose:
+            print("Telegram not configured: missing token or chat ID")
+        return False
+
+    url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
+    payload = {"chat_id": TELEGRAM_CHAT_ID, "text": message}
+
+    try:
+        response = requests.post(url, data=payload, timeout=10)
+        if verbose:
+            print(f"Telegram response: {response.status_code} - {response.text}")
+        response.raise_for_status()
+        return True
+    except Exception as exc:
+        if verbose:
+            print(f"Error sending Telegram message: {exc}")
+        return False

--- a/utils/telegram_report.py
+++ b/utils/telegram_report.py
@@ -1,0 +1,83 @@
+import os
+import re
+from datetime import datetime
+
+from utils.telegram_alert import send_telegram_alert
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LOG_FILE = os.path.join(PROJECT_ROOT, "logs", "events.log")
+PNL_FILE = os.path.join(PROJECT_ROOT, "logs", "pnl.log")
+
+def _parse_today_events(log_path: str, target_date: datetime.date):
+    success = failures = shorts = errors = 0
+    if not os.path.exists(log_path):
+        return success, failures, shorts, errors
+    with open(log_path, encoding="utf-8") as f:
+        for line in f:
+            if not line.startswith("["):
+                continue
+            try:
+                ts_str, msg = line.strip().split("]", 1)
+                ts_date = datetime.strptime(ts_str.lstrip("["), "%Y-%m-%d %H:%M:%S").date()
+            except Exception:
+                continue
+            if ts_date != target_date:
+                continue
+            if "Short y trailing buy" in msg:
+                shorts += 1
+            if "✅" in msg and (
+                "Orden enviada" in msg
+                or "Compra y trailing stop" in msg
+                or "Short y trailing buy" in msg
+            ):
+                success += 1
+            if "Falló la orden" in msg:
+                failures += 1
+            if any(k in msg for k in ["❌", "⚠️", "⛔", "Error"]):
+                errors += 1
+    return success, failures, shorts, errors
+
+def _parse_today_pnl(log_path: str, target_date: datetime.date):
+    wins = losses = 0
+    total = 0.0
+    if not os.path.exists(log_path):
+        return wins, losses, total
+    with open(log_path, encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            if line.startswith("[") and "]" in line:
+                ts_str, remainder = line.split("]", 1)
+                try:
+                    ts_date = datetime.strptime(ts_str.lstrip("["), "%Y-%m-%d %H:%M:%S").date()
+                    if ts_date != target_date:
+                        continue
+                except Exception:
+                    remainder = line
+                line = remainder
+            match = re.search(r"(-?\d+(?:\.\d+)?)", line)
+            if match:
+                value = float(match.group(1))
+                total += value
+                if value >= 0:
+                    wins += 1
+                else:
+                    losses += 1
+    return wins, losses, total
+
+def generate_cumulative_report(verbose: bool = False) -> None:
+    today = datetime.utcnow().date()
+    success, failures, shorts, errors = _parse_today_events(LOG_FILE, today)
+    wins, losses, realized = _parse_today_pnl(PNL_FILE, today)
+
+    message = (
+        f"📊 Resumen del {today}\n"
+        f"✅ Órdenes exitosas: {success}\n"
+        f"❌ Órdenes fallidas: {failures}\n"
+        f"📉 Shorts ejecutados: {shorts}\n"
+        f"⚠️ Errores: {errors}\n"
+        f"💵 PnL realizado: {realized:.2f} USD\n"
+        f"🏆 Ganadoras: {wins} | 💔 Perdedoras: {losses}"
+    )
+
+    send_telegram_alert(message, verbose=verbose)


### PR DESCRIPTION
## Summary
- add `send_telegram_alert` helper for optional Telegram messages
- build `generate_cumulative_report` that summarizes logs and sends via Telegram
- invoke Telegram report from scheduler in isolated try/except so failures don't impact other flows

## Testing
- `python -m py_compile utils/telegram_alert.py utils/telegram_report.py core/scheduler.py`
- `pytest`
- `python -c "from utils.telegram_report import generate_cumulative_report; generate_cumulative_report(verbose=True)"`


------
https://chatgpt.com/codex/tasks/task_e_688e8908c4548324b9549f08fbbe27fd