### PR TITLE
feat: add trade history bonus scoring

### DIFF
--- a/signals/reader.py
+++ b/signals/reader.py
@@ -14,6 +14,8 @@ from signals.scoring import fetch_yfinance_stock_data
 from datetime import datetime
 from utils.logger import log_event
 import yfinance as yf
+import os
+import pandas as pd
 
 
 
@@ -49,6 +51,13 @@ priority_symbols = [
 
 STRICTER_WEEKLY_CHANGE_THRESHOLD = 7
 STRICTER_VOLUME_THRESHOLD = 70_000_000
+
+# Ruta del historial de órdenes para cálculos de bonificación
+ORDERS_HISTORY_FILE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "logs",
+    "orders_history.csv",
+)
 
 import csv
 import random  # <--- AÑADE ESTO
@@ -89,6 +98,46 @@ def has_downtrend(symbol: str, days: int = 4) -> bool:
         return False
 
 
+def get_trade_history_score(symbol: str, min_trades: int = 2) -> int:
+    """Calcula un puntaje de bonificación basado en el historial de operaciones.
+
+    Se suma 1 punto si la tasa de aciertos es >= 60% y otro punto si la
+    rentabilidad media estimada es positiva. No penaliza historiales pobres
+    ni la falta de datos.
+    """
+    try:
+        if not os.path.exists(ORDERS_HISTORY_FILE):
+            return 0
+        df = pd.read_csv(ORDERS_HISTORY_FILE)
+        df = df[df["resultado"].isin(["ganadora", "perdedora"])]
+        symbol_history = df[df["symbol"] == symbol]
+
+        if len(symbol_history) < min_trades:
+            return 0
+
+        win_rate = (symbol_history["resultado"] == "ganadora").mean()
+        score = 0
+        if win_rate >= 0.6:
+            score += 1
+
+        def calc_pnl(row):
+            if row["tipo"] == "long":
+                return (row["precio_salida"] - row["precio_entrada"]) * row["shares"]
+            elif row["tipo"] == "short":
+                return (row["precio_entrada"] - row["precio_salida"]) * row["shares"]
+            return 0
+
+        symbol_history = symbol_history.copy()
+        symbol_history["pnl_estimado"] = symbol_history.apply(calc_pnl, axis=1)
+        if symbol_history["pnl_estimado"].mean() > 0:
+            score += 1
+
+        return score
+    except Exception as e:
+        print(f"⚠️ Error evaluando historial de {symbol}: {e}")
+        return 0
+
+
 evaluated_symbols_today = set()
 last_reset_date = datetime.now().date()
 quiver_semaphore = None
@@ -110,7 +159,12 @@ async def _get_top_signals_async(verbose=False):
             print(f"↩️ [{symbol}] Resultado en caché", flush=True)
             if approved:
                 print(f"✅ {symbol} approved.", flush=True)
-                return (symbol, 90, "Quiver")
+                bonus = get_trade_history_score(symbol)
+                if bonus > 0:
+                    print(
+                        f"✅ {symbol} bonificado con {bonus} puntos por buen historial"
+                    )
+                return (symbol, 90 + bonus, "Quiver")
             return None
 
         print(f"🔎 Checking {symbol}...", flush=True)
@@ -120,7 +174,12 @@ async def _get_top_signals_async(verbose=False):
             quiver_approval_cache[symbol] = approved
             if approved:
                 print(f"✅ {symbol} approved.", flush=True)
-                return (symbol, 90, "Quiver")
+                bonus = get_trade_history_score(symbol)
+                if bonus > 0:
+                    print(
+                        f"✅ {symbol} bonificado con {bonus} puntos por buen historial"
+                    )
+                return (symbol, 90 + bonus, "Quiver")
         except Exception as e:
             print(f"⚠️ Error evaluando señales Quiver para {symbol}: {e}")
         return None
@@ -222,6 +281,13 @@ def get_top_shorts(min_criteria=20, verbose=False):
                 score += CRITERIA_WEIGHTS["volatility_ok"]
             if volume > volume_7d_avg:
                 score += CRITERIA_WEIGHTS["volume_growth"]
+
+            symbol_score = get_trade_history_score(symbol)
+            if symbol_score > 0:
+                print(
+                    f"✅ {symbol} bonificado con {symbol_score} puntos por buen historial"
+                )
+            score += symbol_score
 
             if verbose:
                 print(f"🔻 {symbol}: score={score} (SHORT) → weekly_change={weekly_change}, trend={trend}, price_24h={price_change_24h}")

--- a/tests/test_trade_history_score.py
+++ b/tests/test_trade_history_score.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from signals import reader
+
+
+def test_get_trade_history_score_bonus(tmp_path, monkeypatch):
+    file = tmp_path / "orders_history.csv"
+    df = pd.DataFrame(
+        [
+            {
+                "symbol": "AAA",
+                "tipo": "long",
+                "precio_entrada": 10.0,
+                "precio_salida": 12.0,
+                "shares": 1,
+                "resultado": "ganadora",
+            },
+            {
+                "symbol": "AAA",
+                "tipo": "short",
+                "precio_entrada": 15.0,
+                "precio_salida": 10.0,
+                "shares": 1,
+                "resultado": "ganadora",
+            },
+        ]
+    )
+    df.to_csv(file, index=False)
+    monkeypatch.setattr(reader, "ORDERS_HISTORY_FILE", str(file))
+    assert reader.get_trade_history_score("AAA") == 2


### PR DESCRIPTION
## Summary
- add trade history bonus scoring using past win rate and pnl
- boost get_top_signals and get_top_shorts with trade history bonus
- cover trade history scoring with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689373cedacc8324a895e95957b61e26