### PR TITLE
feat: add adaptive scoring bonus

### DIFF
--- a/signals/adaptive_bonus.py
+++ b/signals/adaptive_bonus.py
@@ -1,0 +1,41 @@
+from broker.alpaca import get_current_price
+from utils.technicals import get_rsi, get_moving_average, is_extremely_volatile
+
+
+def apply_adaptive_bonus(symbol: str, mode: str = "long") -> int:
+    """Apply soft bonus/penalty to final score based on context.
+
+    Parameters
+    ----------
+    symbol: str
+        Ticker symbol being evaluated.
+    mode: str, optional
+        "long" or "short" to adjust RSI penalty direction.
+
+    Returns
+    -------
+    int
+        Bonus (positive) or penalty (negative). Safe-fails to 0 on errors.
+    """
+    try:
+        bonus = 0
+
+        price = get_current_price(symbol)
+        ma7 = get_moving_average(symbol, window=7)
+        if price and ma7 and ma7 != 0 and abs(price - ma7) / ma7 <= 0.03:
+            bonus += 1
+
+        if is_extremely_volatile(symbol):
+            bonus -= 1
+
+        rsi = get_rsi(symbol)
+        if rsi is not None:
+            if mode == "long" and rsi > 80:
+                bonus -= 1
+            if mode == "short" and rsi < 20:
+                bonus -= 1
+
+        return bonus
+    except Exception as e:
+        print(f"⚠️ Error en apply_adaptive_bonus para {symbol}: {e}")
+        return 0

--- a/signals/reader.py
+++ b/signals/reader.py
@@ -13,6 +13,7 @@ from broker.alpaca import api
 from signals.scoring import fetch_yfinance_stock_data
 from datetime import datetime, timedelta
 from utils.logger import log_event
+from signals.adaptive_bonus import apply_adaptive_bonus
 import yfinance as yf
 import os
 import pandas as pd
@@ -183,7 +184,10 @@ async def _get_top_signals_async(verbose=False):
                     print(
                         f"✅ {symbol} bonificado con {bonus} puntos por buen historial"
                     )
-                return (symbol, 90 + bonus, "Quiver")
+                final_score = 90 + bonus
+                adaptive_bonus = apply_adaptive_bonus(symbol, mode="long")
+                final_score += adaptive_bonus
+                return (symbol, final_score, "Quiver")
             return None
 
         print(f"🔎 Checking {symbol}...", flush=True)
@@ -198,7 +202,10 @@ async def _get_top_signals_async(verbose=False):
                     print(
                         f"✅ {symbol} bonificado con {bonus} puntos por buen historial"
                     )
-                return (symbol, 90 + bonus, "Quiver")
+                final_score = 90 + bonus
+                adaptive_bonus = apply_adaptive_bonus(symbol, mode="long")
+                final_score += adaptive_bonus
+                return (symbol, final_score, "Quiver")
         except Exception as e:
             print(f"⚠️ Error evaluando señales Quiver para {symbol}: {e}")
         return None
@@ -326,6 +333,8 @@ def get_top_shorts(min_criteria=20, verbose=False):
                 print(f"🔻 {symbol}: score={score} (SHORT) → weekly_change={weekly_change}, trend={trend}, price_24h={price_change_24h}")
 
             if score >= min_criteria and is_approved_by_finnhub_and_alphavantage(symbol):
+                adaptive_bonus = apply_adaptive_bonus(symbol, mode="short")
+                score += adaptive_bonus
                 shorts.append((symbol, score, "Técnico"))
             elif verbose:
                 print(f"⛔ {symbol} descartado (short): score={score} o no aprobado por Finnhub/AlphaVantage")

--- a/utils/technicals.py
+++ b/utils/technicals.py
@@ -1,0 +1,47 @@
+import yfinance as yf
+import pandas as pd
+from typing import Optional
+
+
+def get_rsi(symbol: str, period: int = 14) -> Optional[float]:
+    """Return the latest RSI value for the symbol."""
+    try:
+        data = yf.download(symbol, period=f"{period * 3}d", interval="1d", progress=False)
+        if data.empty or "Close" not in data:
+            return None
+        close = data["Close"].astype(float)
+        delta = close.diff().dropna()
+        gain = delta.where(delta > 0, 0.0)
+        loss = -delta.where(delta < 0, 0.0)
+        avg_gain = gain.rolling(window=period).mean()
+        avg_loss = loss.rolling(window=period).mean()
+        rs = avg_gain / avg_loss
+        rsi = 100 - (100 / (1 + rs))
+        return float(rsi.iloc[-1])
+    except Exception:
+        return None
+
+
+def get_moving_average(symbol: str, window: int = 7) -> Optional[float]:
+    """Return simple moving average of closing price."""
+    try:
+        data = yf.download(symbol, period=f"{window * 3}d", interval="1d", progress=False)
+        if data.empty or "Close" not in data:
+            return None
+        return float(data["Close"].tail(window).mean())
+    except Exception:
+        return None
+
+
+def is_extremely_volatile(symbol: str, lookback: int = 5, threshold: float = 0.08) -> bool:
+    """Check if the symbol shows high volatility based on std dev of pct change."""
+    try:
+        data = yf.download(symbol, period=f"{lookback + 1}d", interval="1d", progress=False)
+        if data.empty or "Close" not in data:
+            return False
+        pct_std = data["Close"].pct_change().dropna().std()
+        if pd.isna(pct_std):
+            return False
+        return pct_std > threshold
+    except Exception:
+        return False


### PR DESCRIPTION
## Summary
- add adaptive bonus module to fine-tune scores with RSI, consolidation and volatility context
- expose technical helpers for RSI, moving average and volatility checks
- apply adaptive bonus after main filters in long and short evaluations

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893767a698c83249f377cb8b9de1cb5