### PR TITLE
Fix missing orders history path in blacklist check

### DIFF
--- a/signals/reader.py
+++ b/signals/reader.py
@@ -93,7 +93,9 @@ BLACKLIST_DAYS = 5  # Puede ponerse en config/env si se desea
 
 def is_blacklisted_recent_loser(symbol: str, blacklist_days: int = BLACKLIST_DAYS) -> bool:
     try:
-        df = pd.read_csv("orders_history.csv")
+        if not os.path.exists(ORDERS_HISTORY_FILE):
+            return False
+        df = pd.read_csv(ORDERS_HISTORY_FILE)
         df = df[df["resultado"] == "perdedora"]
         df["fecha_entrada"] = pd.to_datetime(df["fecha_entrada"], errors="coerce")
 


### PR DESCRIPTION
## Summary
- Use `ORDERS_HISTORY_FILE` path when checking for recent losing trades
- Gracefully handle missing order history to avoid noisy warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68939725b9ac83248c02876f6b4cf7c2