### PR TITLE
Keep bot process alive

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ def ping():
 def heartbeat():
     while True:
         print(f"💓 Alive at {datetime.utcnow().isoformat()} UTC", flush=True)
-        time.sleep(900)  # Cada 15 minutos
+        time.sleep(300)  # Cada 5 minutos para evitar inactividad prolongada
 
 
 def launch_all():

--- a/start.py
+++ b/start.py
@@ -1,4 +1,8 @@
 # start.py
 from main import app, launch_all
+import uvicorn
 
 launch_all()  # Lanza los schedulers + heartbeat
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- run Uvicorn when `start.py` is executed directly
- ping heartbeat every 5 minutes to avoid idle shutdown

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893ae9bc5ec8324ac310b466d8bd6c0