### PR TITLE
Improve worker resilience with auto-restart loop and signal handling

### DIFF
--- a/start.py
+++ b/start.py
@@ -1,8 +1,53 @@
-# start.py
-from main import app, launch_all
+"""Robust entry point for the trading bot service.
+
+This script launches all background schedulers and starts the FastAPI server
+using Uvicorn. It also implements basic auto-restart and graceful shutdown
+to avoid unexpected termination in environments like Render.
+"""
+
+import signal
+import time
+
 import uvicorn
 
-launch_all()  # Lanza los schedulers + heartbeat
+from main import app, launch_all
+
+
+shutdown = False
+server = None
+
+
+def handle_exit(sig, frame):
+    """Handle termination signals to stop the server gracefully."""
+    global shutdown, server
+    print(f"⚠️ Señal {sig} recibida. Deteniendo servidor...", flush=True)
+    shutdown = True
+    if server:
+        server.should_exit = True
+
+
+def run_server():
+    """Run Uvicorn without its own signal handlers so we control restarts."""
+    global server
+    config = uvicorn.Config(app, host="0.0.0.0", port=8000)
+    server = uvicorn.Server(config)
+    server.install_signal_handlers = False
+    server.run()
+
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        signal.signal(sig, handle_exit)
+
+    launch_all()  # Lanza los schedulers + heartbeat
+
+    while not shutdown:
+        try:
+            run_server()
+        except Exception as exc:
+            print(f"❌ Server crashed: {exc}", flush=True)
+
+        if not shutdown:
+            print("🔁 Reiniciando servidor en 5s...", flush=True)
+            time.sleep(5)
+


### PR DESCRIPTION
## Summary
- add robust start script that handles SIGTERM/SIGINT
- implement autorestart loop for uvicorn server to keep worker alive

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894d8c6b3bc8324840108cb1159c329