### PR TITLE
Remove custom restart logic from worker

### DIFF
--- a/start.py
+++ b/start.py
@@ -1,8 +1,8 @@
-# start.py
 from main import app, launch_all
+import os
 import uvicorn
 
-launch_all()  # Lanza los schedulers + heartbeat
-
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    launch_all()  # Lanza los schedulers + heartbeat
+    port = int(os.environ.get("PORT", 8000))
+    uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- revert to simple `start.py` without auto-restart or custom signal handlers
- allow Render to supply port via `PORT` env var

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894d8c6b3bc8324840108cb1159c329