### PR TITLE
Introduce resilient worker start script

### DIFF
--- a/start.py
+++ b/start.py
@@ -1,8 +1,34 @@
-# start.py
-from main import app, launch_all
+"""Application entry point for Render background worker.
+
+Launches scheduler tasks via ``launch_all`` then runs Uvicorn. If the server
+crashes unexpectedly it is automatically restarted. Normal shutdown signals are
+handled by Uvicorn so the process exits cleanly when requested.
+"""
+
+from __future__ import annotations
+
+import os
+import time
 import uvicorn
 
-launch_all()  # Lanza los schedulers + heartbeat
+from main import app, launch_all
+
+
+def run_server() -> None:
+    """Run the Uvicorn server respecting the ``PORT`` environment variable."""
+    port = int(os.environ.get("PORT", 8000))
+    uvicorn.run(app, host="0.0.0.0", port=port)
+
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    launch_all()  # Start schedulers and heartbeat
+
+    while True:
+        try:
+            run_server()
+        except Exception:
+            print("\u26a0\ufe0f  Server crashed, restarting...", flush=True)
+            time.sleep(1)
+        else:
+            print("\U0001F44B Server stopped", flush=True)
+            break


### PR DESCRIPTION
## Summary
- run Uvicorn in a restart loop that only relaunches after unexpected crashes
- allow normal SIGINT/SIGTERM to stop the process cleanly while still starting schedulers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894d8c6b3bc8324840108cb1159c329