### PR TITLE
Handle DataFrame results in adaptive trailing stop

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -75,12 +75,17 @@ def get_adaptive_trail_price(symbol):
         hist = yf.download(symbol, period="5d", interval="1d", progress=False)
         if hist.empty or "Close" not in hist.columns:
             raise ValueError("No hay datos")
-        current_price = hist["Close"].iloc[-1]
-        std_pct = hist["Close"].pct_change().dropna().std()
+
+        close_prices = hist["Close"]
+        if isinstance(close_prices, pd.DataFrame):
+            close_prices = close_prices.iloc[:, 0]
+
+        current_price = close_prices.iloc[-1]
+        std_pct = close_prices.pct_change().dropna().std()
         if pd.isna(std_pct) or std_pct <= 0:
             raise ValueError("Desviación inválida")
-        std_pct = min(max(std_pct, 0.005), 0.05)
-        return round(current_price * std_pct, 2)
+        std_pct = min(max(float(std_pct), 0.005), 0.05)
+        return round(float(current_price) * std_pct, 2)
     except Exception as e:
         print(f"⚠️ Error calculando trail adaptativo para {symbol}: {e}")
         fallback_price = get_current_price(symbol)


### PR DESCRIPTION
## Summary
- Ensure adaptive trail price calculation uses a Series by selecting the first column when yfinance returns a DataFrame
- Cast current price and volatility to floats to avoid ambiguous truth values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961a124c5883248609741ed2a469b1