### PR TITLE
feat: refine risk and trailing stops

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -5,6 +5,7 @@
 
 from core.executor import (
     place_order_with_trailing_stop,
+    calculate_investment_amount,
     pending_opportunities,
     pending_trades,
     pending_opportunities_lock,
@@ -42,14 +43,6 @@ initialize_quiver_caches()  # 👈 Llamada a la función antes de iniciar nada m
 
 def get_ny_time():
     return datetime.now(timezone('America/New_York'))
-
-
-def calculate_investment_amount(score, min_score=6, max_score=19, min_investment=2000, max_investment=3000):
-    if score < min_score:
-        return min_investment
-    normalized_score = min(max(score, min_score), max_score)
-    proportion = (normalized_score - min_score) / (max_score - min_score)
-    return int(min_investment + proportion * (max_investment - min_investment))
 
 def pre_market_scan():
     print("🌀 pre_market_scan continuo iniciado.", flush=True)

--- a/tests/test_investment_amount.py
+++ b/tests/test_investment_amount.py
@@ -1,0 +1,28 @@
+import os
+
+os.environ.setdefault("APCA_API_KEY_ID", "test")
+os.environ.setdefault("APCA_API_SECRET_KEY", "test")
+os.environ.setdefault("APCA_API_BASE_URL", "https://paper-api.alpaca.markets")
+
+from core import executor
+
+class DummyAccount:
+    def __init__(self, equity):
+        self.equity = str(equity)
+
+
+def test_calculate_investment_amount_limits(monkeypatch):
+    # Patch API to return fixed equity
+    monkeypatch.setattr(executor.api, "get_account", lambda: DummyAccount(10000))
+
+    executor.reset_daily_investment()
+    amount = executor.calculate_investment_amount(19)
+    # Máximo 10% del equity
+    assert amount == 1000
+
+    # Simular capital ya invertido para acercarnos al límite diario (50% equity)
+    executor.add_to_invested(4600)
+    amount2 = executor.calculate_investment_amount(19)
+    # Solo queda disponible 400 USD del límite diario
+    assert amount2 == 400
+


### PR DESCRIPTION
## Summary
- cap per-trade exposure with MAX_POSITION_PCT and remaining daily limit
- derive trailing stops from 14-day ATR and apply to shorts
- add tests to confirm position sizing limits

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e4d411fc832495ed05eabcc4cf1e