### PR TITLE
Add Tiingo, FRED, Reddit data integrations and risk metrics

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,1 @@
+"""Client helpers for external data sources."""

--- a/data/fred_client.py
+++ b/data/fred_client.py
@@ -1,0 +1,74 @@
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+BASE_URL = "https://api.stlouisfed.org/fred/series/observations"
+API_KEY = os.getenv("FRED_API")
+
+
+def _base_params(series_id: str) -> Dict[str, str]:
+    if not API_KEY:
+        raise RuntimeError("FRED_API environment variable not set")
+    return {"series_id": series_id, "api_key": API_KEY, "file_type": "json"}
+
+
+def get_series_observations(series_id: str, observation_start: Optional[str] = None, observation_end: Optional[str] = None, units: str = "lin") -> List[Dict[str, Any]]:
+    """Retrieve observations for a given FRED series.
+
+    Parameters
+    ----------
+    series_id:
+        FRED series identifier (e.g. ``CPIAUCSL`` for CPI).
+    observation_start, observation_end:
+        Optional start/end dates in ``YYYY-MM-DD`` format.
+    units:
+        Transformation applied to data (see FRED docs).
+    """
+    params = _base_params(series_id)
+    params["units"] = units
+    if observation_start:
+        params["observation_start"] = observation_start
+    if observation_end:
+        params["observation_end"] = observation_end
+    response = requests.get(BASE_URL, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("observations", [])
+
+
+def get_latest_value(series_id: str, units: str = "lin") -> Optional[float]:
+    """Return the latest available numeric value for ``series_id``.
+
+    Parameters
+    ----------
+    series_id:
+        FRED series identifier.
+    units:
+        Optional transformation applied to the data (see FRED docs).
+    """
+    observations = get_series_observations(series_id, units=units)
+    for obs in reversed(observations):
+        val = obs.get("value")
+        try:
+            return float(val)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+MACRO_SERIES = {
+    # key -> (series_id, units)
+    "inflation": ("CPIAUCSL", "pc1"),  # Year-over-year % change
+    "unemployment": ("UNRATE", "lin"),  # Civilian Unemployment Rate
+    "fed_funds": ("FEDFUNDS", "lin"),  # Effective Federal Funds Rate
+    "gdp_real": ("GDPC1", "pca"),  # Real GDP, annual rate of change
+}
+
+
+def get_macro_snapshot() -> Dict[str, Optional[float]]:
+    """Return a snapshot of selected macroeconomic series."""
+    snapshot: Dict[str, Optional[float]] = {}
+    for name, (series_id, units) in MACRO_SERIES.items():
+        snapshot[name] = get_latest_value(series_id, units=units)
+    return snapshot

--- a/data/tiingo_client.py
+++ b/data/tiingo_client.py
@@ -1,0 +1,49 @@
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+BASE_URL = "https://api.tiingo.com"
+TOKEN = os.getenv("TIINGO_API")
+
+
+def _auth_headers() -> Dict[str, str]:
+    if not TOKEN:
+        raise RuntimeError("TIINGO_API environment variable not set")
+    return {"Content-Type": "application/json", "Authorization": f"Token {TOKEN}"}
+
+
+def get_daily_prices(ticker: str, start_date: Optional[str] = None, end_date: Optional[str] = None) -> Any:
+    """Fetch historical daily prices for ``ticker`` from Tiingo.
+
+    Parameters
+    ----------
+    ticker:
+        The asset symbol, e.g. ``AAPL``.
+    start_date, end_date:
+        Optional ISO formatted dates (YYYY-MM-DD).
+    """
+    url = f"{BASE_URL}/tiingo/daily/{ticker}/prices"
+    params: Dict[str, str] = {}
+    if start_date:
+        params["startDate"] = start_date
+    if end_date:
+        params["endDate"] = end_date
+    response = requests.get(url, headers=_auth_headers(), params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_iex_quote(ticker: str) -> Any:
+    """Return the latest IEX quote for ``ticker``.
+
+    Example response contains fields like ``last``, ``bidPrice``, ``askPrice``
+    and volume information. See Tiingo's documentation for details.
+    """
+    url = f"{BASE_URL}/iex/{ticker}"
+    response = requests.get(url, headers=_auth_headers(), timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    if isinstance(data, list):
+        return data[0] if data else {}
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ aiohttp>=3.8.3
 matplotlib
 fastapi
 uvicorn
+praw

--- a/signals/reddit_scraper.py
+++ b/signals/reddit_scraper.py
@@ -1,0 +1,73 @@
+import os
+import re
+from typing import Dict, Iterable, List
+
+try:
+    import praw
+except Exception as exc:  # pragma: no cover - optional dependency
+    praw = None
+
+REDDIT_ID = os.getenv("REDDIT_ID")
+REDDIT_SECRET = os.getenv("REDDIT_SECRET")
+REDDIT_USER_AGENT = os.getenv("REDDIT_USER_AGENT")
+
+TICKER_RE = re.compile(r"\b[A-Z]{1,5}\b")
+STOP_WORDS = {"FDA", "CEO", "SEC", "USD", "GDP", "FBI"}
+
+
+def _get_client() -> "praw.Reddit":
+    if praw is None:
+        raise RuntimeError("praw is required for reddit scraping")
+    if not (REDDIT_ID and REDDIT_SECRET and REDDIT_USER_AGENT):
+        raise RuntimeError("Reddit API credentials not set")
+    return praw.Reddit(
+        client_id=REDDIT_ID,
+        client_secret=REDDIT_SECRET,
+        user_agent=REDDIT_USER_AGENT,
+    )
+
+
+def extract_tickers(text: str) -> List[str]:
+    """Return potential ticker symbols found in ``text``."""
+    tickers = {m.group(0).upper() for m in TICKER_RE.finditer(text or "")}
+    return [t for t in tickers if t not in STOP_WORDS]
+
+
+def get_reddit_sentiment(ticker: str, subreddits: Iterable[str] = ("wallstreetbets", "stocks"), limit: int = 50) -> float:
+    """Compute a simple sentiment score based on Reddit mentions.
+
+    The score is based on upvote-to-comment ratio for posts mentioning
+    ``ticker`` across the given ``subreddits``. Result is clamped to [-1, 1].
+    """
+    reddit = _get_client()
+    ticker = ticker.upper()
+    scores: List[float] = []
+    for sub in subreddits:
+        try:
+            for submission in reddit.subreddit(sub).search(ticker, limit=limit, sort="new"):
+                text = f"{submission.title} {submission.selftext}"
+                if ticker in extract_tickers(text):
+                    ups = submission.score
+                    comments = submission.num_comments or 1
+                    scores.append(ups / comments)
+        except Exception:
+            continue
+    if not scores:
+        return 0.0
+    avg = sum(scores) / len(scores)
+    normalized = max(min(avg / 100, 1), -1)  # heuristic normalization
+    return normalized
+
+
+def subreddit_ticker_counts(subreddit: str, limit: int = 100, time_filter: str = "day") -> Dict[str, int]:
+    """Return a count of tickers mentioned in top posts of ``subreddit``."""
+    reddit = _get_client()
+    counts: Dict[str, int] = {}
+    try:
+        for submission in reddit.subreddit(subreddit).top(time_filter=time_filter, limit=limit):
+            tickers = extract_tickers(f"{submission.title} {submission.selftext}")
+            for t in tickers:
+                counts[t] = counts.get(t, 0) + 1
+    except Exception:
+        return counts
+    return counts

--- a/tests/test_risk_adjustment.py
+++ b/tests/test_risk_adjustment.py
@@ -1,0 +1,36 @@
+import os
+import pandas as pd
+
+os.environ.setdefault("APCA_API_KEY_ID", "test")
+os.environ.setdefault("APCA_API_SECRET_KEY", "test")
+
+import core.executor as executor
+
+
+def test_update_risk_limits(monkeypatch):
+    # Simulate high risk environment
+    monkeypatch.setattr(executor, "calculate_var", lambda window=30, confidence=0.95: 0.06)
+    monkeypatch.setattr(executor, "get_max_drawdown", lambda window=30: -12)
+    executor.MAX_POSITION_PCT = 0.10
+    executor.DAILY_INVESTMENT_LIMIT_PCT = 0.50
+    executor.update_risk_limits()
+    assert executor.MAX_POSITION_PCT == 0.05
+    assert executor.DAILY_INVESTMENT_LIMIT_PCT == 0.25
+
+    # Simulate low risk environment
+    monkeypatch.setattr(executor, "calculate_var", lambda window=30, confidence=0.95: 0.02)
+    monkeypatch.setattr(executor, "get_max_drawdown", lambda window=30: -2)
+    executor.update_risk_limits()
+    assert executor.MAX_POSITION_PCT == 0.10
+    assert executor.DAILY_INVESTMENT_LIMIT_PCT == 0.50
+
+
+def test_adaptive_trail_price_window(monkeypatch):
+    data = pd.DataFrame({
+        "High": [10, 11, 12],
+        "Low": [8, 9, 9],
+        "Close": [9, 10, 11],
+    })
+    monkeypatch.setattr(executor.yf, "download", lambda *args, **kwargs: data)
+    price = executor.get_adaptive_trail_price("TST", window=2)
+    assert price == 0.55

--- a/tests/test_source_filters.py
+++ b/tests/test_source_filters.py
@@ -1,0 +1,34 @@
+import os
+from unittest.mock import patch
+
+os.environ.setdefault("APCA_API_KEY_ID", "test")
+os.environ.setdefault("APCA_API_SECRET_KEY", "test")
+
+from signals.filters import is_symbol_approved
+
+
+def test_macro_penalty_can_be_overcome():
+    with patch('signals.filters.macro_score', return_value=-0.5), \
+         patch('signals.filters.volatility_penalty', return_value=0.0), \
+         patch('signals.filters.reddit_score', return_value=0.2), \
+         patch('signals.filters.is_approved_by_quiver', return_value=True):
+        assert is_symbol_approved('AAPL') is True
+
+
+def test_rejects_when_score_negative():
+    with patch('signals.filters.macro_score', return_value=-1.0), \
+         patch('signals.filters.volatility_penalty', return_value=0.3), \
+         patch('signals.filters.reddit_score', return_value=-0.2), \
+         patch('signals.filters.is_approved_by_quiver', return_value=False), \
+         patch('signals.filters.is_approved_by_finnhub_and_alphavantage', return_value=False), \
+         patch('signals.filters.is_approved_by_fmp', return_value=False):
+        assert is_symbol_approved('AAPL') is False
+
+
+def test_approves_when_score_positive():
+    with patch('signals.filters.macro_score', return_value=0.2), \
+         patch('signals.filters.volatility_penalty', return_value=0.1), \
+         patch('signals.filters.reddit_score', return_value=0.3), \
+         patch('signals.filters.is_approved_by_quiver', return_value=True):
+        assert is_symbol_approved('AAPL') is True
+


### PR DESCRIPTION
## Summary
- integrate Tiingo and FRED API clients for market and macro data
- add Reddit sentiment scraper using PRAW and optional ticker counts
- enhance risk utilities with VaR and drawdown calculations and tests
- dynamically tune position sizing limits based on VaR and drawdown
- factor Reddit sentiment, Tiingo volatility, and FRED macro data into approval logic

## Testing
- `pytest`
- `PYTHONPATH=. pytest tests/test_source_filters.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899209acb1c8324aeedd2278e825e4e