### PR TITLE
feat: add state persistence and monitoring

### DIFF
--- a/core/async_executor.py
+++ b/core/async_executor.py
@@ -1,0 +1,20 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import Iterable, Tuple
+
+from core.executor import place_order_with_trailing_stop, calculate_investment_amount
+
+
+async def place_orders_concurrently(opportunities: Iterable[Tuple[str, int]]):
+    """Lanza órdenes en paralelo usando asyncio y un ThreadPoolExecutor."""
+    loop = asyncio.get_event_loop()
+    with ThreadPoolExecutor() as pool:
+        tasks = []
+        for symbol, score in opportunities:
+            amount = calculate_investment_amount(score, symbol=symbol)
+            tasks.append(
+                loop.run_in_executor(
+                    pool, place_order_with_trailing_stop, symbol, amount, 1.5
+                )
+            )
+        return await asyncio.gather(*tasks)

--- a/core/backtester.py
+++ b/core/backtester.py
@@ -1,0 +1,39 @@
+import pandas as pd
+import numpy as np
+from typing import List, Tuple
+
+
+def run_backtest(prices: pd.Series, signals: List[Tuple[pd.Timestamp, str]], initial_capital: float = 10000.0) -> dict:
+    """Simple backtesting engine using close prices and buy/sell signals.
+
+    :param prices: Serie de precios de cierre indexada por fecha.
+    :param signals: Lista de tuplas (fecha, 'buy'|'sell').
+    :return: métricas básicas del rendimiento.
+    """
+    cash = initial_capital
+    position = 0
+    equity_curve = []
+    prices = prices.sort_index()
+    sig_iter = iter(sorted(signals, key=lambda x: x[0]))
+    current_signal = next(sig_iter, None)
+    for date, price in prices.items():
+        while current_signal and current_signal[0] <= date:
+            action = current_signal[1]
+            if action == 'buy' and cash >= price:
+                qty = cash // price
+                cash -= qty * price
+                position += qty
+            elif action == 'sell' and position > 0:
+                cash += position * price
+                position = 0
+            current_signal = next(sig_iter, None)
+        equity_curve.append(cash + position * price)
+    equity = pd.Series(equity_curve, index=prices.index)
+    returns = equity.pct_change().dropna()
+    sharpe = np.sqrt(252) * returns.mean() / returns.std() if not returns.empty else 0
+    drawdown = (equity / equity.cummax() - 1).min()
+    return {
+        "final_equity": float(equity.iloc[-1]) if not equity.empty else initial_capital,
+        "sharpe_ratio": float(sharpe),
+        "max_drawdown": float(drawdown),
+    }

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -7,7 +7,9 @@ from core.executor import (
     open_positions,
     open_positions_lock,
     get_adaptive_trail_price,
+    state_manager,
 )
+from utils.monitoring import update_positions_metric
 
 
 def check_virtual_take_profit_and_stop(symbol, entry_price, qty, position_side):
@@ -72,6 +74,8 @@ def monitor_open_positions():
             with open_positions_lock:
                 open_positions.intersection_update(symbols)
                 open_positions.update(symbols)
+                state_manager.replace_open_positions(open_positions)
+            update_positions_metric(len(open_positions))
 
             if not positions:
                 print("⚠️ No hay posiciones abiertas actualmente.")

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -93,7 +93,7 @@ def pre_market_scan():
                         evaluated_symbols_today.add(symb)
                         continue
 
-                    amount_usd = calculate_investment_amount(score)
+                    amount_usd = calculate_investment_amount(score, symbol=symb)
                     log_event(f"🟡 Ejecutando orden para {symb}")
                     log_event(f"🛒 Intentando comprar {symb} por {amount_usd} USD")
                     success = place_order_with_trailing_stop(symb, amount_usd, 1.5)

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 import threading
 import time
 from core.scheduler import start_schedulers
+from utils.monitoring import start_metrics_server
 from datetime import datetime
 
 app = FastAPI()
@@ -22,4 +23,5 @@ def heartbeat():
 def launch_all():
     print("🟢 Lanzando schedulers...", flush=True)
     start_schedulers()
+    start_metrics_server()
     threading.Thread(target=heartbeat, daemon=True).start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ matplotlib
 fastapi
 uvicorn
 praw
+prometheus-client

--- a/signals/aggregator.py
+++ b/signals/aggregator.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+class WeightedSignalAggregator:
+    """Combina señales externas asignando pesos a cada una."""
+    def __init__(self, weights: Dict[str, float] | None = None):
+        self.weights = weights or {}
+
+    def combine(self, signals: Dict[str, float]) -> float:
+        total = 0.0
+        weight_sum = 0.0
+        for name, value in signals.items():
+            if value is None:
+                continue
+            w = self.weights.get(name, 1.0)
+            total += value * w
+            weight_sum += w
+        return total / weight_sum if weight_sum else 0.0

--- a/utils/monitoring.py
+++ b/utils/monitoring.py
@@ -1,0 +1,20 @@
+try:
+    from prometheus_client import Counter, Gauge, start_http_server
+except Exception:  # pragma: no cover - fallback when dependency missing
+    Counter = Gauge = lambda *a, **k: None  # type: ignore
+
+    def start_http_server(*a, **k):
+        return None
+
+orders_placed = Counter("orders_placed_total", "Total de órdenes enviadas")
+open_positions_gauge = Gauge("open_positions", "Número de posiciones abiertas")
+
+
+def start_metrics_server(port: int = 8001) -> None:
+    if callable(start_http_server):
+        start_http_server(port)
+
+
+def update_positions_metric(count: int) -> None:
+    if hasattr(open_positions_gauge, "set"):
+        open_positions_gauge.set(count)

--- a/utils/scaling.py
+++ b/utils/scaling.py
@@ -1,0 +1,18 @@
+import yfinance as yf
+
+
+def adjust_by_volatility(symbol: str, amount: int, lookback: int = 20) -> int:
+    """Reduce la inversión si la volatilidad histórica es alta."""
+    try:
+        hist = yf.download(symbol, period=f"{lookback}d", interval="1d", progress=False)
+        if hist.empty or "Close" not in hist:
+            return amount
+        pct = hist["Close"].pct_change().dropna()
+        vol = pct.std()
+        if vol > 0.05:
+            return int(amount * 0.5)
+        if vol > 0.03:
+            return int(amount * 0.75)
+    except Exception:
+        return amount
+    return int(amount)

--- a/utils/state.py
+++ b/utils/state.py
@@ -1,0 +1,42 @@
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Iterable, Set
+
+class StateManager:
+    """Persist simple bot state like open positions using SQLite."""
+    def __init__(self, db_path: str = "data/state.db"):
+        self.db_path = Path(db_path)
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _init_db(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS open_positions(symbol TEXT PRIMARY KEY)"
+            )
+
+    def load_open_positions(self) -> Set[str]:
+        with self._lock, sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute("SELECT symbol FROM open_positions").fetchall()
+            return {r[0] for r in rows}
+
+    def add_open_position(self, symbol: str) -> None:
+        with self._lock, sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO open_positions(symbol) VALUES (?)", (symbol,)
+            )
+
+    def remove_open_position(self, symbol: str) -> None:
+        with self._lock, sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM open_positions WHERE symbol=?", (symbol,))
+
+    def replace_open_positions(self, symbols: Iterable[str]) -> None:
+        symbols = set(symbols)
+        with self._lock, sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM open_positions")
+            conn.executemany(
+                "INSERT INTO open_positions(symbol) VALUES (?)",
+                [(s,) for s in symbols],
+            )


### PR DESCRIPTION
## Summary
- persist open positions using SQLite for crash recovery
- expose Prometheus-style metrics and dynamic volatility sizing
- add signal weighting, simple backtester and async order helper
- update metrics gauge whenever open positions change

## Testing
- `pytest` *(killed during tests/test_get_top_signals.py)*

------
https://chatgpt.com/codex/tasks/task_e_689b8ace163c8324b9069180ae676806