### PR TITLE
Prevent running system when market closed

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import threading
 import time
 from core.scheduler import start_schedulers
 from datetime import datetime
+from broker.alpaca import is_market_open
 
 app = FastAPI()
 
@@ -20,6 +21,9 @@ def heartbeat():
 
 
 def launch_all():
+    if not is_market_open():
+        print("⛔ Mercado cerrado. Schedulers no iniciados.", flush=True)
+        return
     print("🟢 Lanzando schedulers...", flush=True)
     start_schedulers()
     threading.Thread(target=heartbeat, daemon=True).start()

--- a/start.py
+++ b/start.py
@@ -1,6 +1,13 @@
 # start.py
-from main import app, launch_all
+import sys
 import uvicorn
+from broker.alpaca import is_market_open
+from main import app, launch_all
+
+# Evitar iniciar el sistema si el mercado está cerrado
+if not is_market_open():
+    print("⛔ Mercado cerrado. El sistema no se iniciará.", flush=True)
+    sys.exit(0)
 
 launch_all()  # Lanza los schedulers + heartbeat
 


### PR DESCRIPTION
## Summary
- exit startup early if market is closed
- skip scheduler launch when market closed

## Testing
- `PYTHONPATH=. pytest tests` *(fails: HTTPSConnectionPool(host='api.quiverquant.com', port=443): Max retries exceeded ... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bbb4c98b883248159d70388c22a24