### PR TITLE
Avoid repeated restarts when market closed

### DIFF
--- a/start.py
+++ b/start.py
@@ -1,15 +1,16 @@
 # start.py
-import sys
 import uvicorn
 from broker.alpaca import is_market_open
 from main import app, launch_all
 
 # Evitar iniciar el sistema si el mercado está cerrado
-if not is_market_open():
-    print("⛔ Mercado cerrado. El sistema no se iniciará.", flush=True)
-    sys.exit(0)
-
-launch_all()  # Lanza los schedulers + heartbeat
+if is_market_open():
+    launch_all()  # Lanza los schedulers + heartbeat
+else:
+    print(
+        "⛔ Mercado cerrado. La API permanecerá activa pero los schedulers no se iniciarán.",
+        flush=True,
+    )
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- Keep API server running even when the market is closed
- Skip scheduler launch when the market is closed to prevent repeated restarts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c77036a748324af53ac056626038f