### PR TITLE
feat: expand fmp helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,6 @@ $ python utils/log_summary.py
 Set `FMP_API_KEY` to enable optional fallbacks to the Financial Modeling Prep API.
 The bot will use FMP's stock screener when basic price data is missing and will
 monitor analyst grade news to place small $10 trades when ratings switch between
-buy/hold/sell.
+buy/hold/sell.  Additional helpers expose company profiles, quotes and
+fundamental metrics like financial ratios and key metrics for strategies that
+need deeper fundamentals.

--- a/signals/fmp_utils.py
+++ b/signals/fmp_utils.py
@@ -51,7 +51,9 @@ def _get(endpoint: str, params: dict | None = None, max_retries: int = 3):
             return resp.json()
         except Exception as e:
             print(f"⚠️ FMP request failed ({endpoint}): {e}")
-            return None
+            if attempt == max_retries - 1:
+                return None
+            time.sleep(2 ** attempt)
     return None
 
 def stock_screener(**params):
@@ -61,6 +63,24 @@ def stock_screener(**params):
 def shares_float(symbol: str):
     """Get company share float and liquidity information."""
     return _get("shares-float", {"symbol": symbol})
+
+def company_profile(symbol: str):
+    """Fetch basic company profile information."""
+    return _get(f"profile/{symbol}")
+
+def quote(symbol: str):
+    """Return the latest market quote for ``symbol``."""
+    return _get(f"quote/{symbol}")
+
+def financial_ratios(symbol: str, period: str = "annual", limit: int = 5):
+    """Retrieve financial ratios such as PE and debt/equity."""
+    params = {"period": period, "limit": limit}
+    return _get(f"ratios/{symbol}", params)
+
+def key_metrics(symbol: str, period: str = "annual", limit: int = 5):
+    """Return key metrics like revenue per share."""
+    params = {"period": period, "limit": limit}
+    return _get(f"key-metrics/{symbol}", params)
 
 def cot_report(symbol: str, from_date: str | None = None, to_date: str | None = None):
     params = {"symbol": symbol}

--- a/tests/test_fmp_utils.py
+++ b/tests/test_fmp_utils.py
@@ -39,3 +39,53 @@ def test_get_retries_on_rate_limit():
     assert req.call_count == 2
     sleep.assert_called()  # ensure a delay was attempted after 429
 
+
+def test_get_retries_on_exception():
+    responses = [
+        requests.ConnectionError("boom"),
+        DummyResponse(200, {"ok": True}),
+    ]
+
+    def fake_request(*args, **kwargs):
+        resp = responses.pop(0)
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+    with patch(
+        "signals.fmp_utils.throttled_request", side_effect=fake_request
+    ) as req, patch("signals.fmp_utils.time.sleep") as sleep:
+        result = fmp_utils._get("test-endpoint")
+
+    assert result == {"ok": True}
+    assert req.call_count == 2
+    sleep.assert_called()
+
+
+def test_company_profile_wrapper_calls_get():
+    with patch("signals.fmp_utils._get") as get_mock:
+        fmp_utils.company_profile("AAPL")
+    get_mock.assert_called_once_with("profile/AAPL")
+
+
+def test_quote_wrapper_calls_get():
+    with patch("signals.fmp_utils._get") as get_mock:
+        fmp_utils.quote("AAPL")
+    get_mock.assert_called_once_with("quote/AAPL")
+
+
+def test_financial_ratios_wrapper_calls_get():
+    with patch("signals.fmp_utils._get") as get_mock:
+        fmp_utils.financial_ratios("AAPL", period="quarter", limit=10)
+    get_mock.assert_called_once_with(
+        "ratios/AAPL", {"period": "quarter", "limit": 10}
+    )
+
+
+def test_key_metrics_wrapper_calls_get():
+    with patch("signals.fmp_utils._get") as get_mock:
+        fmp_utils.key_metrics("AAPL", period="annual", limit=5)
+    get_mock.assert_called_once_with(
+        "key-metrics/AAPL", {"period": "annual", "limit": 5}
+    )
+


### PR DESCRIPTION
## Summary
- add wrappers for FMP profile, quote, ratios, and key metrics endpoints
- test new helpers
- document expanded FMP usage
- improve `_get` retry logic for generic failures

## Testing
- `python -m pytest tests/test_fmp_utils.py -q`
- `pytest -q` *(fails: Quiver API proxy errors, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689c80756db08324b5000f30d5fe57c8