### PR TITLE
Support fractional share trading

### DIFF
--- a/core/backtester.py
+++ b/core/backtester.py
@@ -20,7 +20,7 @@ def run_backtest(prices: pd.Series, signals: List[Tuple[pd.Timestamp, str]], ini
         while current_signal and current_signal[0] <= date:
             action = current_signal[1]
             if action == 'buy' and cash >= price:
-                qty = cash // price
+                qty = cash / price
                 cash -= qty * price
                 position += qty
             elif action == 'sell' and position > 0:

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -19,7 +19,7 @@ def check_virtual_take_profit_and_stop(symbol, entry_price, qty, position_side):
         if current_price is None or entry_price is None or qty is None:
             return
 
-        qty = int(abs(float(qty)))
+        qty = abs(float(qty))
         if qty <= 0:
             return
 
@@ -33,7 +33,7 @@ def check_virtual_take_profit_and_stop(symbol, entry_price, qty, position_side):
         if gain_pct >= 7 or gain_pct <= -5:
             open_orders = api.list_orders(status="open")
             reserved_qty = sum(
-                int(float(o.qty))
+                float(o.qty)
                 for o in open_orders
                 if o.symbol == symbol and o.side == close_side
             )
@@ -137,12 +137,12 @@ def watchdog_trailing_stop():
                 if (symbol, side) in trailing:
                     continue
 
-                qty = int(float(pos.qty))
+                qty = float(pos.qty)
                 if qty <= 0:
                     continue
 
                 reserved_qty = sum(
-                    int(float(o.qty))
+                    float(o.qty)
                     for o in open_orders
                     if o.symbol == symbol and o.side == side
                 )


### PR DESCRIPTION
## Summary
- Allow fractional quantities when submitting long and short orders
- Track and manage fractional positions in monitoring utilities
- Update backtester logic for fractional position sizing

## Testing
- `pytest` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_689cc8304f8883248e86587c6727f311