### PR TITLE
Round crypto notional to two decimals

### DIFF
--- a/core/crypto_worker.py
+++ b/core/crypto_worker.py
@@ -43,7 +43,10 @@ def crypto_worker() -> None:
 
         signals = get_crypto_signals()
         for symbol, score in signals:
-            alloc = min(_calculate_allocation(score), crypto_limit.remaining())
+            raw_alloc = min(
+                _calculate_allocation(score), crypto_limit.remaining()
+            )
+            alloc = round(raw_alloc, 2)
             if alloc <= 0 or not crypto_limit.can_spend(alloc):
                 continue
             try:

--- a/utils/crypto_limit.py
+++ b/utils/crypto_limit.py
@@ -34,7 +34,7 @@ class CryptoLimit:
         """Recalculate limit and reset the spent tracker."""
         api = get_api()
         acct = api.get_account()
-        self.max_notional = float(acct.buying_power) * 0.10
+        self.max_notional = round(float(acct.buying_power) * 0.10, 2)
         self._spent = 0.0
         clock = api.get_clock()
         # ``next_open`` already accounts for weekends/holidays
@@ -51,9 +51,10 @@ class CryptoLimit:
         """Return ``True`` and deduct ``amount`` if within today's limit."""
         with self._lock:
             self.check_reset()
+            amount = round(amount, 2)
             if self._spent + amount > self.max_notional:
                 return False
-            self._spent += amount
+            self._spent = round(self._spent + amount, 2)
             return True
 
     # ------------------------------------------------------------------
@@ -61,7 +62,7 @@ class CryptoLimit:
         """Return remaining notional before hitting the daily cap."""
         with self._lock:
             self.check_reset()
-            return self.max_notional - self._spent
+            return round(self.max_notional - self._spent, 2)
 
     # ------------------------------------------------------------------
     @property


### PR DESCRIPTION
## Summary
- Round crypto allocations to two decimal places before submitting orders
- Ensure crypto spending limits track amounts with two-decimal precision

## Testing
- `pytest -q` *(fails: lingering thread requires manual interruption; 15 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689e61d45174832480301aeb241ccda9