### PR TITLE
Allow crypto bot to run outside equity market hours

### DIFF
--- a/start.py
+++ b/start.py
@@ -1,16 +1,5 @@
-# start.py
 import uvicorn
-from broker.alpaca import is_market_open
-from main import app, launch_all
-
-# Evitar iniciar el sistema si el mercado está cerrado
-if is_market_open():
-    launch_all()  # Lanza los schedulers + heartbeat
-else:
-    print(
-        "⛔ Mercado cerrado. La API permanecerá activa pero los schedulers no se iniciarán.",
-        flush=True,
-    )
+from main import app
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- Launch schedulers on FastAPI startup only when the stock market is open
- Start a dedicated crypto worker when the market is closed
- Simplify `start.py` to rely on FastAPI startup hooks

## Testing
- `PYTHONPATH=. pytest tests/test_crypto_limit.py`
- `pytest` *(fails: ImportError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_689e68868aec8324b08a082636cb6db5