### PR TITLE
Avoid Quiver cache call on import

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -40,7 +40,6 @@ import pandas as pd
 import time as pytime
 
 from signals.quiver_utils import initialize_quiver_caches, reset_daily_approvals  # 👈 Añadido aquí
-initialize_quiver_caches()  # 👈 Llamada a la función antes de iniciar nada más
 
 from core.crypto_worker import crypto_trades, crypto_trades_lock, crypto_worker
 from utils.crypto_limit import get_crypto_limit
@@ -260,6 +259,10 @@ def daily_summary():
 def start_schedulers():
     print("🟢 Iniciando verificación de symbols.csv...", flush=True)
     regenerate = True
+
+    # Inicializa cachés de Quiver solo cuando se lanzan los schedulers
+    # para evitar llamadas de red innecesarias durante las importaciones.
+    initialize_quiver_caches()
 
     try:
         if os.path.exists("data/symbols.csv"):

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -39,7 +39,7 @@ import os
 import pandas as pd
 import time as pytime
 
-from signals.quiver_utils import initialize_quiver_caches, reset_daily_approvals  # 👈 Añadido aquí
+from signals.quiver_utils import initialize_quiver_caches, reset_daily_approvals
 
 from core.crypto_worker import crypto_trades, crypto_trades_lock, crypto_worker
 from utils.crypto_limit import get_crypto_limit


### PR DESCRIPTION
## Summary
- Avoid initializing Quiver caches at import time to prevent unintended network calls
- Initialize caches within `start_schedulers` for explicit setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f58b55a2083249db86f8f9854a700