### PR TITLE
Use FMP grade endpoint

### DIFF
--- a/signals/fmp_utils.py
+++ b/signals/fmp_utils.py
@@ -107,7 +107,9 @@ def grades_news(symbol: str, page: int = 0, limit: int = 1):
         time.sleep(GRADES_NEWS_MIN_INTERVAL - elapsed)
     _last_grades_news_call = time.time()
     params = {"symbol": symbol, "page": page, "limit": limit}
-    return _get("grades-news", params)
+    # The FMP endpoint for analyst grade news is `grade`, which accepts symbol,
+    # page and limit parameters just like the older `grades-news` path.
+    return _get("grade", params)
 
 
 def get_fmp_grade_score(symbol: str) -> float | None:

--- a/tests/test_fmp_utils.py
+++ b/tests/test_fmp_utils.py
@@ -89,3 +89,10 @@ def test_key_metrics_wrapper_calls_get():
         "key-metrics/AAPL", {"period": "annual", "limit": 5}
     )
 
+
+def test_grades_news_calls_grade_endpoint():
+    """grades_news should query the new `grade` endpoint with params."""
+    with patch("signals.fmp_utils._get") as get_mock:
+        fmp_utils.grades_news("AAPL", page=2, limit=3)
+    get_mock.assert_called_once_with("grade", {"symbol": "AAPL", "page": 2, "limit": 3})
+


### PR DESCRIPTION
## Summary
- query FMP grade data from the `grade` endpoint
- test `grades_news` wrapper ensures new endpoint and parameters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f7072b40c83249711cb5ae2d8a701