### PR TITLE
Ensure fractional orders use DAY time in force

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -18,6 +18,7 @@ from utils.daily_risk import (
     get_max_drawdown,
 )
 from utils.order_tracker import record_trade_result
+from utils.orders import resolve_time_in_force
 import os
 import csv
 import json
@@ -449,7 +450,7 @@ def place_order_with_trailing_stop(symbol, amount_usd, trail_percent=1.0):
             qty=qty,
             side='buy',
             type='market',
-            time_in_force='gtc'
+            time_in_force=resolve_time_in_force(qty)
         )
         orders_placed.inc()
         print(
@@ -476,7 +477,7 @@ def place_order_with_trailing_stop(symbol, amount_usd, trail_percent=1.0):
                 qty=qty,
                 side='sell',
                 type='limit',
-                time_in_force='gtc',
+                time_in_force=resolve_time_in_force(qty),
                 limit_price=take_profit,
             )
             orders_placed.inc()
@@ -492,7 +493,7 @@ def place_order_with_trailing_stop(symbol, amount_usd, trail_percent=1.0):
             qty=qty,
             side='sell',
             type='trailing_stop',
-            time_in_force='gtc',
+            time_in_force=resolve_time_in_force(qty),
             trail_price=trail_price
         )
         orders_placed.inc()
@@ -573,7 +574,7 @@ def place_short_order_with_trailing_buy(symbol, amount_usd, trail_percent=1.0):
             qty=qty,
             side='sell',
             type='market',
-            time_in_force='gtc'
+            time_in_force=resolve_time_in_force(qty)
         )
         orders_placed.inc()
 
@@ -588,7 +589,7 @@ def place_short_order_with_trailing_buy(symbol, amount_usd, trail_percent=1.0):
             qty=qty,
             side='buy',
             type='trailing_stop',
-            time_in_force='gtc',
+            time_in_force=resolve_time_in_force(qty),
             trail_price=trail_price
         )
         orders_placed.inc()

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -3,6 +3,7 @@
 import time
 from broker.alpaca import api, get_current_price
 from utils.logger import log_event
+from utils.orders import resolve_time_in_force
 from core.executor import (
     open_positions,
     open_positions_lock,
@@ -62,7 +63,7 @@ def check_virtual_take_profit_and_stop(symbol, entry_price, qty, position_side):
                 qty=available_qty,
                 side=close_side,
                 type="market",
-                time_in_force="gtc",
+                time_in_force=resolve_time_in_force(available_qty),
             )
 
             if gain_pct >= TAKE_PROFIT_PCT:
@@ -176,7 +177,7 @@ def watchdog_trailing_stop():
                         qty=available_qty,
                         side=side,
                         type="trailing_stop",
-                        time_in_force="gtc",
+                        time_in_force=resolve_time_in_force(available_qty),
                         trail_price=trail_price,
                     )
                     log_event(f"🚨 Trailing stop de emergencia colocado para {symbol}")

--- a/utils/orders.py
+++ b/utils/orders.py
@@ -1,0 +1,14 @@
+def resolve_time_in_force(qty, default="gtc"):
+    """Return 'day' if ``qty`` is fractional, otherwise ``default``.
+
+    Args:
+        qty: Quantity of shares for the order.
+        default: Time in force to use when ``qty`` is a whole number.
+    """
+    try:
+        q = float(qty)
+        if abs(q - round(q)) > 1e-6:
+            return "day"
+    except Exception:
+        pass
+    return default


### PR DESCRIPTION
## Summary
- ensure fractional share orders use `DAY` time in force
- update monitoring and execution logic to apply dynamic time in force

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f759cc5f88324b81f8aa9cef72bb1