### PR TITLE
Fix FMP grade endpoint to avoid 404

### DIFF
--- a/signals/fmp_utils.py
+++ b/signals/fmp_utils.py
@@ -106,10 +106,10 @@ def grades_news(symbol: str, page: int = 0, limit: int = 1):
     if elapsed < GRADES_NEWS_MIN_INTERVAL:
         time.sleep(GRADES_NEWS_MIN_INTERVAL - elapsed)
     _last_grades_news_call = time.time()
-    params = {"symbol": symbol, "page": page, "limit": limit}
-    # The FMP endpoint for analyst grade news is `grade`, which accepts symbol,
-    # page and limit parameters just like the older `grades-news` path.
-    return _get("grade", params)
+    params = {"page": page, "limit": limit}
+    # The FMP endpoint for analyst grade news expects the symbol in the path.
+    # Using query parameters results in a 404 from the API.
+    return _get(f"grade/{symbol}", params)
 
 
 def get_fmp_grade_score(symbol: str) -> float | None:

--- a/tests/test_fmp_utils.py
+++ b/tests/test_fmp_utils.py
@@ -91,8 +91,8 @@ def test_key_metrics_wrapper_calls_get():
 
 
 def test_grades_news_calls_grade_endpoint():
-    """grades_news should query the new `grade` endpoint with params."""
+    """grades_news should query the `grade` endpoint with the symbol in the path."""
     with patch("signals.fmp_utils._get") as get_mock:
         fmp_utils.grades_news("AAPL", page=2, limit=3)
-    get_mock.assert_called_once_with("grade", {"symbol": "AAPL", "page": 2, "limit": 3})
+    get_mock.assert_called_once_with("grade/AAPL", {"page": 2, "limit": 3})
 


### PR DESCRIPTION
## Summary
- call FMP grade endpoint with symbol in path to resolve 404 errors
- update unit test to match new call signature

## Testing
- `PYTHONPATH=. pytest tests/test_fmp_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8bc0f17c832490b3a80db5ebd84c