### PR TITLE
Handle fractional crypto time in force

### DIFF
--- a/core/monitor.py
+++ b/core/monitor.py
@@ -20,7 +20,9 @@ STOP_LOSS_PCT = -3
 MAX_LOSS_USD = 50
 
 
-def check_virtual_take_profit_and_stop(symbol, entry_price, qty, position_side):
+def check_virtual_take_profit_and_stop(
+    symbol, entry_price, qty, position_side, asset_class
+):
     """Cierra la posición si alcanza un take profit virtual (+5%), stop loss (-3%) o pérdida monetaria (-50 USD)."""
     try:
         current_price = get_current_price(symbol)
@@ -63,7 +65,9 @@ def check_virtual_take_profit_and_stop(symbol, entry_price, qty, position_side):
                 qty=available_qty,
                 side=close_side,
                 type="market",
-                time_in_force=resolve_time_in_force(available_qty),
+                time_in_force=resolve_time_in_force(
+                    available_qty, asset_class=asset_class
+                ),
             )
 
             if gain_pct >= TAKE_PROFIT_PCT:
@@ -110,7 +114,11 @@ def monitor_open_positions():
 
                 if symbol in open_positions:
                     check_virtual_take_profit_and_stop(
-                        symbol, avg_entry_price, qty, getattr(p, "side", "long")
+                        symbol,
+                        avg_entry_price,
+                        qty,
+                        getattr(p, "side", "long"),
+                        getattr(p, "asset_class", "us_equity"),
                     )
 
                 positions_data.append(
@@ -177,7 +185,9 @@ def watchdog_trailing_stop():
                         qty=available_qty,
                         side=side,
                         type="trailing_stop",
-                        time_in_force=resolve_time_in_force(available_qty),
+                        time_in_force=resolve_time_in_force(
+                            available_qty, asset_class=getattr(pos, "asset_class", "us_equity")
+                        ),
                         trail_price=trail_price,
                     )
                     log_event(f"🚨 Trailing stop de emergencia colocado para {symbol}")

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+os.environ.setdefault("APCA_API_KEY_ID", "test")
+os.environ.setdefault("APCA_API_SECRET_KEY", "test")
+
+# Ensure project root is on sys.path for module resolution
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils.orders import resolve_time_in_force
+
+
+def test_resolve_time_in_force_crypto_fractional():
+    assert resolve_time_in_force(0.5, asset_class="crypto") == "gtc"
+
+
+def test_resolve_time_in_force_equity_fractional():
+    assert resolve_time_in_force(0.5, asset_class="us_equity") == "day"

--- a/utils/orders.py
+++ b/utils/orders.py
@@ -1,13 +1,19 @@
-def resolve_time_in_force(qty, default="gtc"):
-    """Return 'day' if ``qty`` is fractional, otherwise ``default``.
+def resolve_time_in_force(qty, default: str = "gtc", asset_class: str = "us_equity"):
+    """Return a suitable ``time_in_force`` based on ``qty`` and ``asset_class``.
+
+    For fractional **equity** orders, Alpaca requires ``time_in_force='day'``. Crypto
+    pairs, however, are always fractionable and do not accept ``day`` orders, so we
+    fall back to ``default`` for them.
 
     Args:
-        qty: Quantity of shares for the order.
-        default: Time in force to use when ``qty`` is a whole number.
+        qty: Quantity of shares/units for the order.
+        default: Time in force to use when ``qty`` is a whole number or when the
+            asset class does not enforce special handling.
+        asset_class: Alpaca asset class (e.g. ``us_equity`` or ``crypto``).
     """
     try:
         q = float(qty)
-        if abs(q - round(q)) > 1e-6:
+        if abs(q - round(q)) > 1e-6 and asset_class != "crypto":
             return "day"
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- avoid using unsupported `day` time-in-force on fractional crypto positions
- cover crypto and equity behaviour in `resolve_time_in_force` tests

## Testing
- `pytest tests/test_orders.py`


------
https://chatgpt.com/codex/tasks/task_e_68a04a128f708324a4b615085e37cc0e