### PR TITLE
Handle market opening to start schedulers

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,9 @@ from utils.monitoring import start_metrics_server
 
 app = FastAPI()
 
+# Flag para evitar iniciar los schedulers múltiples veces
+schedulers_started = threading.Event()
+
 @app.get("/ping")
 def ping():
     return {"status": "ok", "time": datetime.utcnow().isoformat()}
@@ -23,9 +26,15 @@ def heartbeat():
         time.sleep(300)  # Cada 5 minutos para evitar inactividad prolongada
 
 
+def start_schedulers_once():
+    if not schedulers_started.is_set():
+        start_schedulers()
+        schedulers_started.set()
+
+
 def launch_all():
     print("🟢 Lanzando schedulers...", flush=True)
-    start_schedulers()
+    start_schedulers_once()
     start_metrics_server()
     threading.Thread(target=heartbeat, daemon=True).start()
 
@@ -35,6 +44,16 @@ def launch_crypto_only():
     threading.Thread(target=crypto_worker, daemon=True).start()
     start_metrics_server()
     threading.Thread(target=heartbeat, daemon=True).start()
+
+
+def await_market_open():
+    """Espera a que abra el mercado para iniciar los schedulers de acciones."""
+    while not schedulers_started.is_set():
+        if is_market_open():
+            print("🔔 Mercado abierto. Iniciando schedulers de acciones...", flush=True)
+            start_schedulers_once()
+            break
+        time.sleep(60)
 
 
 @app.on_event("startup")
@@ -47,3 +66,5 @@ def on_startup():
             flush=True,
         )
         launch_crypto_only()
+    # Siempre lanzar un hilo que vigile la apertura del mercado
+    threading.Thread(target=await_market_open, daemon=True).start()


### PR DESCRIPTION
## Summary
- Start schedulers only once via a thread-safe event
- Add background watcher that triggers schedulers when the market opens

## Testing
- `pytest -q` *(fails: Cannot connect to proxy for quiverquant API, after 17 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a347a0d69c8324af467a40fc68fa9e