### PR TITLE
Use FMP grades-news endpoint

### DIFF
--- a/signals/fmp_utils.py
+++ b/signals/fmp_utils.py
@@ -112,10 +112,9 @@ def grades_news(symbol: str, page: int = 0, limit: int = 1):
     if elapsed < GRADES_NEWS_MIN_INTERVAL:
         time.sleep(GRADES_NEWS_MIN_INTERVAL - elapsed)
     _last_grades_news_call = time.time()
-    params = {"page": page, "limit": limit}
-    # The FMP endpoint for analyst grade news expects the symbol in the path.
-    # Using query parameters results in a 404 from the API.
-    return _get(f"grade/{symbol}", params)
+    params = {"symbol": symbol, "page": page, "limit": limit}
+    # The FMP Stock Grade News endpoint expects the symbol as a query parameter.
+    return _get("grades-news", params)
 
 
 def get_fmp_grade_score(symbol: str) -> float | None:

--- a/tests/test_fmp_utils.py
+++ b/tests/test_fmp_utils.py
@@ -91,10 +91,12 @@ def test_key_metrics_wrapper_calls_get():
 
 
 def test_grades_news_calls_grade_endpoint():
-    """grades_news should query the `grade` endpoint with the symbol in the path."""
+    """grades_news should query the `grades-news` endpoint with symbol param."""
     with patch("signals.fmp_utils._get") as get_mock:
         fmp_utils.grades_news("AAPL", page=2, limit=3)
-    get_mock.assert_called_once_with("grade/AAPL", {"page": 2, "limit": 3})
+    get_mock.assert_called_once_with(
+        "grades-news", {"symbol": "AAPL", "page": 2, "limit": 3}
+    )
 
 
 def test_price_target_news_calls_endpoint():


### PR DESCRIPTION
## Summary
- use FMP Stock Grade News endpoint with symbol query parameter
- adjust tests for new endpoint

## Testing
- `PYTHONPATH=. pytest tests/test_fmp_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a34c9818d8832483c016fdc96f5d51