### PR TITLE
Persist symbol scan progress and enforce deterministic ordering

### DIFF
--- a/signals/reader.py
+++ b/signals/reader.py
@@ -64,15 +64,16 @@ ORDERS_HISTORY_FILE = os.path.join(
 )
 
 import csv
-import random  # <--- AÑADE ESTO
 
 def fetch_symbols_from_csv(path="data/symbols.csv"):
     try:
         with open(path, newline='') as csvfile:
             reader = csv.DictReader(csvfile)
             symbols = [row["Symbol"] for row in reader if row.get("Symbol")]
-            random.shuffle(symbols)  
-            print(f"📄 Se cargaron {len(symbols)} símbolos desde {path}")
+            symbols.sort()
+            print(
+                f"📄 Se cargaron {len(symbols)} símbolos desde {path} en orden fijo"
+            )
             return symbols
     except Exception as e:
         print(f"❌ Error leyendo CSV de símbolos desde '{path}': {e}")


### PR DESCRIPTION
## Summary
- Persist `pre_market_scan` progress in `data/pre_market_progress.json` so symbols aren't reprocessed after restart
- Load symbols from CSV in fixed sorted order for consistent, unidirectional scans

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a389e344648324a2c586c1dc5f731a