### PR TITLE
Avoid duplicate daily emails and show PnL symbols

### DIFF
--- a/tests/test_daily_risk.py
+++ b/tests/test_daily_risk.py
@@ -64,8 +64,26 @@ def test_pnl_breakdown(monkeypatch, tmp_path):
         writer.writerow([today, "CCC", "0"])
 
     wins, losses, total = daily_risk.get_today_pnl_breakdown()
-    assert wins == 2
+    assert wins == 1
     assert losses == 1
+    assert total == 5
+
+
+def test_pnl_details(monkeypatch, tmp_path):
+    log_file = tmp_path / "daily_pnl_log.csv"
+    monkeypatch.setattr(daily_risk, "PNL_LOG_FILE", log_file)
+
+    today = datetime.utcnow().date().isoformat()
+    with open(log_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["date", "symbol", "pnl_usd"])
+        writer.writerow([today, "AAA", "10"])
+        writer.writerow([today, "BBB", "-5"])
+        writer.writerow([today, "CCC", "0"])
+
+    wins, losses, total = daily_risk.get_today_pnl_details()
+    assert wins == ["AAA"]
+    assert losses == ["BBB"]
     assert total == 5
 
 

--- a/utils/daily_risk.py
+++ b/utils/daily_risk.py
@@ -78,10 +78,43 @@ def get_today_pnl_breakdown() -> tuple[int, int, float]:
             except ValueError:
                 continue
             total += pnl
-            if pnl >= 0:
+            if pnl > 0:
                 wins += 1
-            else:
+            elif pnl < 0:
                 losses += 1
+    return wins, losses, total
+
+
+def get_today_pnl_details() -> tuple[list[str], list[str], float]:
+    """Return today's realized PnL with winning and losing symbols.
+
+    Returns
+    -------
+    tuple[list[str], list[str], float]
+        A tuple ``(winning_symbols, losing_symbols, total_pnl)`` for the current UTC date.
+    """
+    if not PNL_LOG_FILE.exists():
+        return [], [], 0.0
+
+    today_str = datetime.utcnow().date().isoformat()
+    wins: list[str] = []
+    losses: list[str] = []
+    total = 0.0
+    with open(PNL_LOG_FILE, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row.get("date") != today_str:
+                continue
+            try:
+                pnl = float(row.get("pnl_usd", 0))
+            except ValueError:
+                continue
+            total += pnl
+            symbol = row.get("symbol", "")
+            if pnl > 0:
+                wins.append(symbol)
+            elif pnl < 0:
+                losses.append(symbol)
     return wins, losses, total
 
 


### PR DESCRIPTION
## Summary
- Track last summary date and guard daily summary with a lock to prevent multiple emails
- Include winning and losing trade symbols in daily email using new helper
- Exclude flat PnL trades from win/loss counts and symbol lists
- Add unit test for detailed PnL reporting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e9e05d508324beb83c5ac8530b22