### PR TITLE
Avoid redundant signal evaluation

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -78,7 +78,17 @@ def pre_market_scan():
 
             # Obtener señales solo una vez por ciclo
             get_cached_positions(refresh=True)
-            evaluated_opportunities = get_top_signals(verbose=True)
+
+            # Construir conjunto de exclusión para evitar reevaluaciones
+            exclude_symbols = set(evaluated_symbols_today)
+            with pending_opportunities_lock:
+                exclude_symbols.update(pending_opportunities)
+            with executed_symbols_today_lock:
+                exclude_symbols.update(executed_symbols_today)
+
+            evaluated_opportunities = get_top_signals(
+                verbose=True, exclude=exclude_symbols
+            )
 
             if evaluated_opportunities:
                 print(f"🔎 {len(evaluated_opportunities)} oportunidades encontradas.", flush=True)

--- a/tests/test_get_top_signals.py
+++ b/tests/test_get_top_signals.py
@@ -72,3 +72,18 @@ def test_get_top_signals_excludes_blacklisted_symbols():
 
     returned_symbols = {r[0] for r in results}
     assert "B" not in returned_symbols
+
+
+def test_get_top_signals_respects_exclude_param():
+    symbols = ["A", "B", "C"]
+    with patch.object(reader, "stock_assets", symbols), \
+         patch("signals.reader._async_is_approved_by_quiver", new=AsyncMock(return_value=True)), \
+         patch.object(reader, "is_position_open", return_value=False), \
+         patch.object(reader, "get_cached_positions"), \
+         patch.object(reader, "evaluated_symbols_today", set()), \
+         patch.object(reader, "last_reset_date", reader.datetime.now().date()), \
+         patch.object(reader, "is_blacklisted_recent_loser", return_value=False):
+        results = reader.get_top_signals(exclude={"A", "B"})
+
+    returned_symbols = {r[0] for r in results}
+    assert returned_symbols <= {"C"}


### PR DESCRIPTION
## Summary
- allow passing excluded symbols to `get_top_signals`
- scheduler filters out already evaluated, pending or executed tickers
- add tests for new exclude parameter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5d3e86614832487e9c328134b0e9a