### PR TITLE
Improve Quiver API rate limit handling

### DIFF
--- a/signals/quiver_throttler.py
+++ b/signals/quiver_throttler.py
@@ -7,7 +7,7 @@ import threading
 # Variables globales
 REQUEST_LOCK = threading.Lock()
 LAST_REQUEST_TIME = 0
-RATE_LIMIT_DELAY = 1.2  # segundos entre peticiones, ajustable según tu plan
+RATE_LIMIT_DELAY = 2.0  # segundos entre peticiones, ajustable según tu plan
 
 
 def throttled_request(request_func, *args, **kwargs):
@@ -22,7 +22,7 @@ def throttled_request(request_func, *args, **kwargs):
         time_since_last = now - LAST_REQUEST_TIME
 
         if time_since_last < RATE_LIMIT_DELAY:
-            sleep_time = RATE_LIMIT_DELAY - time_since_last + random.uniform(0, 0.5)
+            sleep_time = RATE_LIMIT_DELAY - time_since_last + random.uniform(0, 1.0)
             time.sleep(sleep_time)
 
         try:

--- a/signals/quiver_utils.py
+++ b/signals/quiver_utils.py
@@ -3,6 +3,7 @@
 
 import os
 import time
+import random
 import requests
 import asyncio
 import math
@@ -287,7 +288,7 @@ def evaluate_quiver_signals(signals, symbol=""):
     return True
 
 
-def safe_quiver_request(url, retries=3, delay=2):
+def safe_quiver_request(url, retries=5, delay=4):
     # Log only that the key is present without revealing it
     if QUIVER_API_KEY:
         print("🔑 Usando clave Quiver: [REDACTED]")
@@ -303,6 +304,7 @@ def safe_quiver_request(url, retries=3, delay=2):
             # messages.
             if r.status_code == 429:
                 wait = delay * (2 ** i)
+                wait += random.uniform(0, delay)
                 print(f"⚠️ Límite de velocidad alcanzado en {url}: código {r.status_code}")
                 print(f"🔄 Reintentando en {wait}s...")
                 time.sleep(wait)
@@ -320,6 +322,7 @@ def safe_quiver_request(url, retries=3, delay=2):
         except Exception as e:
             print(f"⚠️ Error en {url}: {e}")
         wait = delay * (2 ** i)
+        wait += random.uniform(0, delay)
         print(f"🔄 Reintentando en {wait}s...")
         time.sleep(wait)
     print(f"❌ Fallo final en {url}. Se devuelve None.")

--- a/tests/test_quiver_utils.py
+++ b/tests/test_quiver_utils.py
@@ -1,0 +1,36 @@
+import requests
+from unittest.mock import patch
+
+from signals import quiver_utils
+
+
+class DummyResponse:
+    def __init__(self, status_code, json_data=None):
+        self.status_code = status_code
+        self._json = json_data or {}
+
+    @property
+    def ok(self):
+        return self.status_code < 400
+
+    def json(self):
+        return self._json
+
+
+def test_safe_quiver_request_retries_on_rate_limit():
+    responses = [
+        DummyResponse(429),
+        DummyResponse(429),
+        DummyResponse(200, {"ok": True}),
+    ]
+
+    def fake_request(*args, **kwargs):
+        return responses.pop(0)
+
+    with patch("signals.quiver_utils.throttled_request", side_effect=fake_request) as req, \
+         patch("signals.quiver_utils.time.sleep") as sleep:
+        result = quiver_utils.safe_quiver_request("test-url")
+
+    assert result == {"ok": True}
+    assert req.call_count == 3
+    assert sleep.call_count == 2


### PR DESCRIPTION
## Summary
- Increase spacing between Quiver API calls and add jittered exponential backoff for rate limit retries
- Add regression test for safe_quiver_request retry behavior

## Testing
- `pytest` *(fails: FMP requests returned 403 and test run interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68acac630f708324a0d13a8261482dab