### PR TITLE
Add advanced order helpers and risk metrics

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -25,7 +25,7 @@ from utils.emailer import send_email
 from utils.backtest_report import generate_paper_summary, analyze_trades, format_summary
 from utils.logger import log_event, log_dir
 from utils.telegram_report import generate_cumulative_report
-from core.monitor import monitor_open_positions, watchdog_trailing_stop
+from core.monitor import monitor_open_positions, watchdog_trailing_stop, cancel_stale_orders_loop
 from utils.generate_symbols_csv import generate_symbols_csv
 from core.grade_news import scan_grade_changes
 from signals.filters import is_position_open, get_cached_positions
@@ -303,6 +303,7 @@ def start_schedulers():
     print("🟢 Lanzando schedulers...", flush=True)
     threading.Thread(target=monitor_open_positions, daemon=True).start()
     threading.Thread(target=watchdog_trailing_stop, daemon=True).start()
+    threading.Thread(target=cancel_stale_orders_loop, daemon=True).start()
     threading.Thread(target=pre_market_scan, daemon=True).start()
     threading.Thread(target=daily_summary, daemon=True).start()
     threading.Thread(target=scan_grade_changes, daemon=True).start()

--- a/tests/test_backtest_from_trades.py
+++ b/tests/test_backtest_from_trades.py
@@ -17,5 +17,6 @@ def test_analyze_trades_basic():
     assert round(stats["win_rate"], 2) == 60.0
     assert stats["average_pnl"] == 4.0
     assert round(stats["max_drawdown"], 2) == 10.0
+    assert round(stats["sharpe_ratio"], 2) == 0.84
     assert stats["top_symbols"][0][0] == "A"
     assert stats["bottom_symbols"][0][0] == "C"

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -7,7 +7,9 @@ os.environ.setdefault("APCA_API_SECRET_KEY", "test")
 # Ensure project root is on sys.path for module resolution
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from utils.orders import resolve_time_in_force
+from utils.orders import resolve_time_in_force, enforce_min_price_increment, submit_bracket_order
+from broker import alpaca
+from unittest import mock
 
 
 def test_resolve_time_in_force_crypto_fractional():
@@ -16,3 +18,31 @@ def test_resolve_time_in_force_crypto_fractional():
 
 def test_resolve_time_in_force_equity_fractional():
     assert resolve_time_in_force(0.5, asset_class="us_equity") == "day"
+
+
+def test_enforce_min_price_increment():
+    assert enforce_min_price_increment(0.123456) == 0.1235
+    assert enforce_min_price_increment(5.6789) == 5.68
+
+
+def test_submit_bracket_order(monkeypatch):
+    called = {}
+
+    def fake_submit_order(**kwargs):
+        called.update(kwargs)
+        return mock.MagicMock(id="1")
+
+    monkeypatch.setattr(alpaca.api, "submit_order", fake_submit_order)
+
+    submit_bracket_order(
+        symbol="AAPL",
+        qty=1,
+        side="buy",
+        take_profit=150.1234,
+        stop_loss=140.1234,
+        limit_price=145.1234,
+    )
+
+    assert called["order_class"] == "bracket"
+    assert called["take_profit"]["limit_price"] == 150.12
+    assert called["stop_loss"]["stop_price"] == 140.12

--- a/utils/orders.py
+++ b/utils/orders.py
@@ -18,3 +18,132 @@ def resolve_time_in_force(qty, default: str = "gtc", asset_class: str = "us_equi
     except Exception:
         pass
     return default
+
+
+def enforce_min_price_increment(price: float) -> float:
+    """Round ``price`` to the maximum decimals allowed by Alpaca.
+
+    Alpaca rejects limit or stop prices that include more than two decimals when
+    the value is greater or equal to 1 USD, or more than four decimals when it is
+    below 1 USD.  This helper rounds the provided value accordingly so that
+    callers do not need to worry about manual validation.
+
+    Args:
+        price: Raw price to be used in an order.
+
+    Returns:
+        ``price`` rounded to the permitted number of decimals.
+    """
+
+    if price is None:
+        return price
+    try:
+        p = float(price)
+    except Exception:
+        return price
+    return round(p, 2) if p >= 1 else round(p, 4)
+
+
+def _submit_order_with_class(**kwargs):
+    """Internal helper to call ``api.submit_order``.
+
+    Separated for easier testing/mocking.
+    """
+
+    from broker.alpaca import api  # Local import to avoid circular deps
+
+    return api.submit_order(**kwargs)
+
+
+def submit_bracket_order(
+    symbol: str,
+    qty,
+    side: str,
+    take_profit: float,
+    stop_loss: float,
+    limit_price: float | None = None,
+    time_in_force: str = "gtc",
+):
+    """Submit a bracket order combining entry, take-profit and stop-loss.
+
+    Only the bare minimum parameters are exposed; callers can extend this helper
+    or submit orders directly for more advanced scenarios.
+    """
+
+    payload = {
+        "symbol": symbol,
+        "qty": qty,
+        "side": side,
+        "type": "market" if limit_price is None else "limit",
+        "time_in_force": time_in_force,
+        "order_class": "bracket",
+        "take_profit": {"limit_price": enforce_min_price_increment(take_profit)},
+        "stop_loss": {"stop_price": enforce_min_price_increment(stop_loss)},
+    }
+    if limit_price is not None:
+        payload["limit_price"] = enforce_min_price_increment(limit_price)
+    return _submit_order_with_class(**payload)
+
+
+def submit_oco_order(
+    symbol: str,
+    qty,
+    side: str,
+    take_profit: float,
+    stop_loss: float,
+    stop_limit: float | None = None,
+    time_in_force: str = "gtc",
+):
+    """Submit an OCO order combining take-profit and stop-loss after entry."""
+
+    stop_payload = {"stop_price": enforce_min_price_increment(stop_loss)}
+    if stop_limit is not None:
+        stop_payload["limit_price"] = enforce_min_price_increment(stop_limit)
+
+    payload = {
+        "symbol": symbol,
+        "qty": qty,
+        "side": side,
+        "type": "limit",
+        "time_in_force": time_in_force,
+        "order_class": "oco",
+        "take_profit": {"limit_price": enforce_min_price_increment(take_profit)},
+        "stop_loss": stop_payload,
+    }
+    return _submit_order_with_class(**payload)
+
+
+def submit_oto_order(
+    symbol: str,
+    qty,
+    side: str,
+    stop_loss: float | None = None,
+    take_profit: float | None = None,
+    limit_price: float | None = None,
+    time_in_force: str = "gtc",
+):
+    """Submit an OTO order with either a stop-loss or take-profit leg."""
+
+    if stop_loss is None and take_profit is None:
+        raise ValueError("Either stop_loss or take_profit must be provided")
+
+    payload = {
+        "symbol": symbol,
+        "qty": qty,
+        "side": side,
+        "type": "market" if limit_price is None else "limit",
+        "time_in_force": time_in_force,
+        "order_class": "oto",
+    }
+    if limit_price is not None:
+        payload["limit_price"] = enforce_min_price_increment(limit_price)
+    if take_profit is not None:
+        payload["take_profit"] = {
+            "limit_price": enforce_min_price_increment(take_profit)
+        }
+    if stop_loss is not None:
+        payload["stop_loss"] = {
+            "stop_price": enforce_min_price_increment(stop_loss)
+        }
+    return _submit_order_with_class(**payload)
+


### PR DESCRIPTION
## Summary
- add helper methods for bracket, OCO, and OTO orders with price increment validation
- compute Sharpe ratio in backtest summary
- automatically cancel stale open orders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0ebf0d348324b35eb98a10cbf6ab