### PR TITLE
Log approved and rejected symbols in daily report

### DIFF
--- a/utils/emailer.py
+++ b/utils/emailer.py
@@ -21,12 +21,13 @@ def send_email(subject, body, attach_log=False):
         message.attach(MIMEText(body, "plain"))
 
         if attach_log:
-            log_file_path = os.path.join(log_dir, "events.log")
-            if os.path.exists(log_file_path):
-                with open(log_file_path, "rb") as log_file:
-                    part = MIMEApplication(log_file.read(), Name="events.log")
-                    part['Content-Disposition'] = 'attachment; filename="events.log"'
-                    message.attach(part)
+            for fname in ("events.log", "approvals.log"):
+                log_file_path = os.path.join(log_dir, fname)
+                if os.path.exists(log_file_path):
+                    with open(log_file_path, "rb") as log_file:
+                        part = MIMEApplication(log_file.read(), Name=fname)
+                        part['Content-Disposition'] = f'attachment; filename="{fname}"'
+                        message.attach(part)
 
         with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
             server.login(EMAIL_SENDER, EMAIL_PASSWORD)


### PR DESCRIPTION
## Summary
- Track approved and rejected symbols per day and write them to `approvals.log`.
- Include daily approval results in end-of-day email summary and attach approvals log alongside events.
- Add tests for multiple log attachments.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae1325b82883249e591ecca3b7bc4a