### PR TITLE
Fix crypto symbol format to avoid Alpaca 404 error

### DIFF
--- a/signals/crypto_signals.py
+++ b/signals/crypto_signals.py
@@ -27,7 +27,7 @@ def get_crypto_signals(limit: int = 5) -> List[Tuple[str, int]]:
     results: List[Tuple[str, int]] = []
     for item in data.get("coins", []):
         sym = item.get("item", {}).get("symbol", "").upper()
-        alpaca_symbol = f"{sym}/USD"
+        alpaca_symbol = f"{sym}USD"
         try:
             asset = api.get_asset(alpaca_symbol)
             if asset.tradable:


### PR DESCRIPTION
## Summary
- remove slash from crypto symbols when building Alpaca symbol names to match Alpaca's API

## Testing
- `pytest -q` *(fails to terminate cleanly due to external API warnings; all 19 tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68ae151a4db48324ab3fc0401822eb7c