### PR TITLE
Randomize symbol evaluation cycle

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -19,7 +19,7 @@ from core.executor import (
 )
 
 from core.options_trader import run_options_strategy, get_options_log_and_reset
-from signals.reader import get_top_signals
+from signals.reader import get_top_signals, stock_assets, reset_symbol_rotation
 from broker.alpaca import api, is_market_open
 from utils.emailer import send_email
 from utils.backtest_report import generate_paper_summary, analyze_trades, format_summary
@@ -74,6 +74,15 @@ def pre_market_scan():
 
         # Obtener señales solo una vez por ciclo
         get_cached_positions(refresh=True)
+
+        # Reiniciar rotación si todos los símbolos fueron evaluados
+        if len(evaluated_longs_today) >= len(stock_assets):
+            evaluated_longs_today.clear()
+            reset_symbol_rotation()
+            print(
+                "🔄 Todos los símbolos evaluados. Reiniciando lista de evaluación.",
+                flush=True,
+            )
 
         # Construir conjunto de exclusión para evitar reevaluaciones
         exclude_symbols = set(evaluated_longs_today)

--- a/signals/reader.py
+++ b/signals/reader.py
@@ -222,6 +222,13 @@ def _save_evaluated_symbols():
 _load_evaluated_symbols()
 
 
+def reset_symbol_rotation():
+    """Shuffle the symbol universe and clear evaluation progress."""
+    random.shuffle(stock_assets)
+    evaluated_symbols_today.clear()
+    _save_evaluated_symbols()
+
+
 def get_top_signals(verbose=False, exclude=None):
     """Return up to five top trading opportunities.
 
@@ -344,9 +351,9 @@ async def _get_top_signals_async(verbose=False, exclude=None):
         symbols_to_evaluate = filtered_symbols[:100]
         random.shuffle(symbols_to_evaluate)
 
-        # Si no hay símbolos restantes, esperar sin reevaluar en la misma sesión
         if not symbols_to_evaluate:
-            print("⏳ Sin símbolos nuevos para evaluar hoy.")
+            print("🔄 Todos los símbolos evaluados. Reiniciando ciclo.")
+            reset_symbol_rotation()
             await asyncio.sleep(60)
             continue
 


### PR DESCRIPTION
## Summary
- Shuffle symbol universe and reset progress when all symbols have been scanned
- Reset scheduler's evaluation list once every symbol has been processed to avoid repeats

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af56836f108324aa6950c4ac4c6f18