### PR TITLE
Prevent repeated symbol handling in trading sessions

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -49,6 +49,8 @@ evaluated_shorts_today_lock = evaluated_shorts_today.lock
 EVALUATED_LONGS_FILE = os.path.join(DATA_DIR, "evaluated_longs.json")
 evaluated_longs_today = DailySet(EVALUATED_LONGS_FILE)
 evaluated_longs_today_lock = evaluated_longs_today.lock
+TRAILING_ERROR_FILE = os.path.join(DATA_DIR, "trailing_error_symbols.json")
+trailing_error_symbols = DailySet(TRAILING_ERROR_FILE)
 
 # Locks for thread-safe access to the remaining sets
 open_positions_lock = threading.Lock()
@@ -215,7 +217,9 @@ def get_adaptive_trail_price(symbol, window: int = 14):
         gc.collect()
         return result
     except Exception as e:
-        print(f"⚠️ Error calculando trail adaptativo para {symbol}: {e}")
+        if symbol not in trailing_error_symbols:
+            print(f"⚠️ Error calculando trail adaptativo para {symbol}: {e}")
+            trailing_error_symbols.add(symbol)
         fallback_price = get_current_price(symbol)
         return round(fallback_price * 0.015, 2)
 

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -325,8 +325,10 @@ def cancel_stale_orders_loop():
             for o in open_orders:
                 submitted = getattr(o, "submitted_at", None)
                 tif = getattr(o, "time_in_force", "")
-                if not submitted:
+                otype = getattr(o, "type", "")
+                if not submitted or otype in ("trailing_stop", "stop", "stop_limit"):
                     continue
+
                 age_min = (now - submitted.replace(tzinfo=None)).total_seconds() / 60
                 if age_min > STALE_ORDER_MINUTES or (
                     tif == "day" and not is_market_open()


### PR DESCRIPTION
## Summary
- Skip trailing, stop and stop-limit orders in stale order cancellation to avoid re-creating trailing stops repeatedly
- Persist symbols with adaptive trail price errors to log each symbol only once per day

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0bbdcb2348324b77948fbc7aec73f