### PR TITLE
Ensure symbols need external approval before reporting as approved

### DIFF
--- a/signals/filters.py
+++ b/signals/filters.py
@@ -169,19 +169,23 @@ def is_symbol_approved(symbol):
     score -= volatility_penalty(symbol)
     score += reddit_score(symbol)
 
+    had_external_approval = False
     if is_approved_by_quiver(symbol):
         print(f"✅ {symbol} aprobado por Quiver")
         score += 1.0
+        had_external_approval = True
     else:
         print(f"➡️ {symbol} no pasó filtro Quiver. Evaluando Finnhub y AlphaVantage...")
         if is_approved_by_finnhub_and_alphavantage(symbol):
             print(f"✅ {symbol} aprobado por Finnhub + AlphaVantage")
             score += 0.5
+            had_external_approval = True
         elif is_approved_by_fmp(symbol):
             score += 0.25
+            had_external_approval = True
 
     print(f"📈 Score final {symbol}: {score:.2f}")
-    approved = score > 0
+    approved = score > 0 and had_external_approval
     if approved:
         approved_symbols_today.add(symbol)
     else:

--- a/tests/test_source_filters.py
+++ b/tests/test_source_filters.py
@@ -20,6 +20,17 @@ def test_rejects_when_score_negative():
          patch('signals.filters.volatility_penalty', return_value=0.3), \
          patch('signals.filters.reddit_score', return_value=-0.2), \
          patch('signals.filters.is_approved_by_quiver', return_value=False), \
+        patch('signals.filters.is_approved_by_finnhub_and_alphavantage', return_value=False), \
+        patch('signals.filters.is_approved_by_fmp', return_value=False):
+        assert is_symbol_approved('AAPL') is False
+
+
+def test_requires_external_approval():
+    """Even with a positive score, lack of external approval should reject."""
+    with patch('signals.filters.macro_score', return_value=0.2), \
+         patch('signals.filters.volatility_penalty', return_value=0.1), \
+         patch('signals.filters.reddit_score', return_value=0.2), \
+         patch('signals.filters.is_approved_by_quiver', return_value=False), \
          patch('signals.filters.is_approved_by_finnhub_and_alphavantage', return_value=False), \
          patch('signals.filters.is_approved_by_fmp', return_value=False):
         assert is_symbol_approved('AAPL') is False


### PR DESCRIPTION
## Summary
- require at least one external data source to approve a symbol before marking it as approved
- add regression test for missing external approval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0bffab8a08324a2b8c56cb45478ac