### PR TITLE
feat: add negative news filter

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -4,12 +4,14 @@ from datetime import datetime
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 log_dir = os.path.join(PROJECT_ROOT, "logs")
 
-def log_event(message):
+
+def log_event(message, **fields):
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, "events.log")
 
     timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
-    log_line = f"[{timestamp}] {message}"
+    extra = " ".join(f"{k}={v}" for k, v in fields.items())
+    log_line = f"[{timestamp}] {message}" + (f" {extra}" if extra else "")
 
     print(log_line)
     with open(log_file, "a", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- implement negative news filter using FMP Stock News API
- classify articles via keyword lists and log evaluations
- support structured keyword fields in `log_event`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e42ddd948324bd412b8235f50302