### PR TITLE
Remove macro approvals and add market exposure factor

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -3,3 +3,10 @@ gate:
   min_cap: 500e6
   min_avg_vol_20d: 500000
   strong_signal_max_age_days: 3
+
+market:
+  avoid_earnings_days: 3
+  avoid_last_minutes: 20
+  default_exposure: 0.85   # usado si no hay régimen calculado
+  min_exposure: 0.6
+  max_exposure: 1.0

--- a/signals/filters.py
+++ b/signals/filters.py
@@ -10,7 +10,6 @@ import alpaca_trade_api as tradeapi
 from dotenv import load_dotenv
 
 from data.tiingo_client import get_daily_prices
-from data.fred_client import get_macro_snapshot
 from signals.quiver_utils import is_approved_by_quiver
 from signals.reddit_scraper import get_reddit_sentiment
 from utils.daily_set import DailySet
@@ -218,25 +217,6 @@ def has_negative_news(symbol: str, days_back: int = 2) -> bool:
         return False
 
 
-def macro_score() -> float:
-    """Return a macroeconomic score based on FRED data.
-
-    Positive values indicate a favorable environment, negative values a headwind.
-    """
-    score = 0.0
-    try:
-        snapshot = get_macro_snapshot()
-        inflation = snapshot.get("inflation")
-        unemployment = snapshot.get("unemployment")
-        if inflation is not None:
-            score += (2 - inflation) / 10  # reward low inflation, penalize high
-        if unemployment is not None:
-            score += (5 - unemployment) / 10  # reward low unemployment
-    except Exception as e:
-        print(f"⚠️ FRED macro check failed: {e}")
-    return score
-
-
 def reddit_score(symbol: str) -> float:
     """Fetch Reddit sentiment score for ``symbol`` (-1 to 1)."""
     try:
@@ -318,9 +298,9 @@ def is_approved_by_finnhub_and_alphavantage(symbol):
     return fmp
 
 def is_symbol_approved(symbol):
+    """La decisión por-ticker no usa macro; el ajuste macro se aplica a tamaño en core/executor.py."""
     print(f"\n🚦 Iniciando análisis de aprobación para {symbol}...")
     score = 0.0
-    score += macro_score()
     score -= volatility_penalty(symbol)
     score += reddit_score(symbol)
 

--- a/tests/test_daily_cache_exposure.py
+++ b/tests/test_daily_cache_exposure.py
@@ -1,0 +1,42 @@
+from datetime import datetime as real_datetime
+
+
+def test_daily_cache_exposure(monkeypatch):
+    from core.executor import get_market_exposure_factor, _market_exposure_state
+
+    class DT1:
+        @classmethod
+        def utcnow(cls):
+            return real_datetime(2023, 1, 1, 12, 0, 0)
+
+    class DT2:
+        @classmethod
+        def utcnow(cls):
+            return real_datetime(2023, 1, 2, 12, 0, 0)
+
+    call_count = {"n": 0}
+
+    def regime_high():
+        call_count["n"] += 1
+        return "high_vol"
+
+    def regime_normal():
+        call_count["n"] += 1
+        return "normal"
+
+    cfg = type("Cfg", (), {"market": type("M", (), {})()})()
+
+    monkeypatch.setattr("core.executor.datetime", DT1)
+    monkeypatch.setattr("utils.cache.get_cached_market_regime", regime_high)
+    _market_exposure_state["last_calculated"] = None
+    _market_exposure_state["factor"] = 1.0
+    first = get_market_exposure_factor(cfg)
+    second = get_market_exposure_factor(cfg)
+    assert first == second == 0.7
+    assert call_count["n"] == 1
+
+    monkeypatch.setattr("core.executor.datetime", DT2)
+    monkeypatch.setattr("utils.cache.get_cached_market_regime", regime_normal)
+    third = get_market_exposure_factor(cfg)
+    assert third == 1.0
+    assert call_count["n"] == 2

--- a/tests/test_executor_sizing_scale.py
+++ b/tests/test_executor_sizing_scale.py
@@ -10,9 +10,10 @@ class Cfg:
     pass
 
 
-def test_calculate_investment_amount_scaling():
+def test_calculate_investment_amount_scaling(monkeypatch):
     equity = 50000
     cfg = Cfg()
+    monkeypatch.setattr("core.executor.get_market_exposure_factor", lambda cfg: 1.0)
     assert calculate_investment_amount(0, equity, cfg) == 2000
     assert calculate_investment_amount(100, equity, cfg) == min(3000, 0.10 * equity)
     mid = calculate_investment_amount(50, equity, cfg)

--- a/tests/test_exposure_factor_applied.py
+++ b/tests/test_exposure_factor_applied.py
@@ -1,0 +1,17 @@
+
+def test_exposure_factor_modulates_size(monkeypatch):
+    from core.executor import calculate_investment_amount
+
+    class Cfg:
+        pass
+
+    cfg = Cfg()
+    equity = 20000
+
+    monkeypatch.setattr("core.executor.get_market_exposure_factor", lambda cfg: 1.0)
+    full = calculate_investment_amount(80, equity, cfg)
+
+    monkeypatch.setattr("core.executor.get_market_exposure_factor", lambda cfg: 0.7)
+    reduced = calculate_investment_amount(80, equity, cfg)
+
+    assert reduced < full and abs(reduced / full - 0.7) < 1e-6

--- a/tests/test_filters_no_macro.py
+++ b/tests/test_filters_no_macro.py
@@ -1,0 +1,13 @@
+import sys
+
+def test_is_symbol_approved_no_macro(monkeypatch):
+    from signals import filters
+
+    monkeypatch.setattr(filters, "volatility_penalty", lambda s: 0.0)
+    monkeypatch.setattr(filters, "reddit_score", lambda s: 0.0)
+    monkeypatch.setattr(filters, "is_approved_by_quiver", lambda s: True)
+    monkeypatch.setattr(filters, "is_approved_by_finnhub_and_alphavantage", lambda s: False)
+    monkeypatch.setattr(filters, "is_approved_by_fmp", lambda s: False)
+
+    assert filters.is_symbol_approved("AAPL") is True
+    assert "data.fred_client" not in sys.modules

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -1,0 +1,8 @@
+_cached = {}
+
+def get_cached_market_regime():
+    # placeholder: devolver None u opciones "normal", "elevated_vol", "high_vol"
+    return _cached.get("market_regime")
+
+def set_cached_market_regime(value: str):
+    _cached["market_regime"] = value


### PR DESCRIPTION
## Summary
- Remove macro/FRED dependency from per-ticker approval and add clarifying docstring
- Introduce daily-cached market exposure factor and apply it to investment sizing
- Add market exposure configuration stub and helper cache module with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4aec24170832492cfc8edfbdc6c64