### PR TITLE
Implement quiver override approval with consensus and logging

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -6,3 +6,11 @@ gate:
 
 score:
   strong_recency_hours: 48
+
+approvals:
+  quiver_override: true         # permite aprobar solo por Quiver fuerte
+  consensus_required: 2         # de {Quiver, FinnhubAlpha, FMP}
+  quiver_strong:
+    recency_hours: 48           # “fresco” para override
+    score_threshold: 8.0        # umbral de convicción Quiver (ajustable)
+    require_recent_event: true  # además de score, exige evento <= recency_hours

--- a/core/executor.py
+++ b/core/executor.py
@@ -402,7 +402,7 @@ def place_order_with_trailing_stop(symbol, amount_usd, trail_percent=1.0):
         return False
     print(f"\n🚀 Iniciando proceso de compra para {symbol} por ${amount_usd}...")
     try:
-        if not is_symbol_approved(symbol):
+        if not is_symbol_approved(symbol, 0, config._policy):
             print(f"❌ {symbol} no aprobado para compra según criterios de análisis.")
             return False
 
@@ -575,7 +575,7 @@ def place_short_order_with_trailing_buy(symbol, amount_usd, trail_percent=1.0):
         return
     print(f"\n🚀 Iniciando proceso de short para {symbol} por ${amount_usd}...")
     try:
-        if not is_symbol_approved(symbol):
+        if not is_symbol_approved(symbol, 0, config._policy):
             print(f"❌ {symbol} no aprobado para short según criterios de análisis.")
             return
 

--- a/tests/test_approval_cache.py
+++ b/tests/test_approval_cache.py
@@ -1,0 +1,27 @@
+import os, sys
+os.environ.setdefault("APCA_API_KEY_ID", "key")
+os.environ.setdefault("APCA_API_SECRET_KEY", "secret")
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import signals.filters as f
+
+
+class Cfg(dict):
+    pass
+
+
+def test_approval_cache(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_votes(symbol, cfg):
+        calls["count"] += 1
+        return {"Quiver": True, "FinnhubAlpha": True, "FMP": False}
+
+    cfg = Cfg(approvals={"quiver_override": False, "consensus_required": 2})
+    monkeypatch.setattr(f, "_is_quiver_strong", lambda s, cfg: False)
+    monkeypatch.setattr(f, "_provider_votes", fake_votes)
+    f._APPROVAL_CACHE.clear()
+    assert f.is_symbol_approved("AAA", 80, cfg) is True
+    assert calls["count"] == 1
+    assert f.is_symbol_approved("AAA", 80, cfg) is True
+    assert calls["count"] == 1

--- a/tests/test_approval_logging.py
+++ b/tests/test_approval_logging.py
@@ -1,0 +1,32 @@
+import os, sys
+os.environ.setdefault("APCA_API_KEY_ID", "key")
+os.environ.setdefault("APCA_API_SECRET_KEY", "secret")
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import signals.filters as f
+
+
+class Cfg(dict):
+    pass
+
+
+def test_approval_logging(monkeypatch):
+    messages = []
+    monkeypatch.setattr(f, "log_event", lambda msg: messages.append(msg))
+    cfg = Cfg(approvals={"quiver_override": True, "consensus_required": 2})
+    # Override message
+    monkeypatch.setattr(f, "_is_quiver_strong", lambda s, cfg: True)
+    f._APPROVAL_CACHE.clear()
+    assert f.is_symbol_approved("T1", 80, cfg) is True
+    assert any("Quiver OVERRIDE" in m for m in messages)
+    # Consensus message
+    messages.clear()
+    monkeypatch.setattr(f, "_is_quiver_strong", lambda s, cfg: False)
+    monkeypatch.setattr(
+        f,
+        "_provider_votes",
+        lambda s, cfg: {"Quiver": True, "FinnhubAlpha": True, "FMP": False},
+    )
+    f._APPROVAL_CACHE.clear()
+    assert f.is_symbol_approved("T2", 80, cfg) is True
+    assert any("Consenso" in m for m in messages)

--- a/tests/test_approval_no_strong_recheck.py
+++ b/tests/test_approval_no_strong_recheck.py
@@ -8,10 +8,17 @@ import signals.gates as gates
 
 
 def test_approval_does_not_call_gate(monkeypatch):
-    monkeypatch.setattr(filters, "macro_score", lambda: 0.0)
-    monkeypatch.setattr(filters, "volatility_penalty", lambda s: 0.0)
-    monkeypatch.setattr(filters, "reddit_score", lambda s: 0.0)
-    monkeypatch.setattr(filters, "is_approved_by_finnhub_and_alphavantage", lambda s: True)
-    monkeypatch.setattr(filters, "is_approved_by_fmp", lambda s: False)
-    monkeypatch.setattr(gates, "_has_strong_recent_quiver_signal", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("should not be called")))
-    assert filters.is_symbol_approved("AAPL") is True
+    monkeypatch.setattr(
+        gates,
+        "_has_strong_recent_quiver_signal",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("should not be called")),
+    )
+    monkeypatch.setattr(filters, "_is_quiver_strong", lambda s, cfg: False)
+    monkeypatch.setattr(
+        filters,
+        "_provider_votes",
+        lambda s, cfg: {"Quiver": True, "FinnhubAlpha": True, "FMP": False},
+    )
+    filters._APPROVAL_CACHE.clear()
+    cfg = {"approvals": {"quiver_override": False, "consensus_required": 2}}
+    assert filters.is_symbol_approved("AAPL", 0, cfg) is True

--- a/tests/test_approval_override_quiver.py
+++ b/tests/test_approval_override_quiver.py
@@ -1,0 +1,45 @@
+import os, sys
+os.environ.setdefault("APCA_API_KEY_ID", "key")
+os.environ.setdefault("APCA_API_SECRET_KEY", "secret")
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import signals.filters as f
+
+
+class Cfg(dict):
+    pass
+
+
+def test_quiver_override_and_consensus(monkeypatch):
+    cfg = Cfg(
+        approvals={
+            "quiver_override": True,
+            "consensus_required": 2,
+            "quiver_strong": {
+                "recency_hours": 48,
+                "score_threshold": 8.0,
+                "require_recent_event": True,
+            },
+        }
+    )
+    # Override on
+    monkeypatch.setattr(f, "_is_quiver_strong", lambda s, cfg: True)
+    f._APPROVAL_CACHE.clear()
+    assert f.is_symbol_approved("TEST", 80, cfg) is True
+    # Override off → consenso 2/3
+    monkeypatch.setattr(f, "_is_quiver_strong", lambda s, cfg: False)
+    monkeypatch.setattr(
+        f,
+        "_provider_votes",
+        lambda s, cfg: {"Quiver": True, "FinnhubAlpha": True, "FMP": False},
+    )
+    f._APPROVAL_CACHE.clear()
+    assert f.is_symbol_approved("TEST", 80, cfg) is True
+    # 1/3 → falla
+    monkeypatch.setattr(
+        f,
+        "_provider_votes",
+        lambda s, cfg: {"Quiver": False, "FinnhubAlpha": True, "FMP": False},
+    )
+    f._APPROVAL_CACHE.clear()
+    assert f.is_symbol_approved("TEST", 80, cfg) is False

--- a/tests/test_idempotent_order.py
+++ b/tests/test_idempotent_order.py
@@ -16,7 +16,7 @@ def test_idempotent_order(monkeypatch):
     # Patch environment to avoid real API calls
     monkeypatch.setattr(order_utils, "alpaca_order_exists", lambda cid: True)
     monkeypatch.setattr(executor, "log_event", lambda *a, **k: None)
-    monkeypatch.setattr(executor, "is_symbol_approved", lambda s: True)
+    monkeypatch.setattr(executor, "is_symbol_approved", lambda s, score, cfg: True)
     monkeypatch.setattr(executor, "is_position_open", lambda s: False)
     monkeypatch.setattr(executor, "get_current_price", lambda s: 10.0)
     monkeypatch.setattr(executor.api, "get_account", lambda: types.SimpleNamespace(equity="10000", buying_power="10000", cash="10000"))

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -8,6 +8,7 @@ log_dir = os.path.join(PROJECT_ROOT, "logs")
 def log_event(message, **fields):
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, "events.log")
+    approval_file = os.path.join(log_dir, "approvals.log")
 
     timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
     extra = " ".join(f"{k}={v}" for k, v in fields.items())
@@ -16,3 +17,6 @@ def log_event(message, **fields):
     print(log_line)
     with open(log_file, "a", encoding="utf-8") as f:
         f.write(log_line + "\n")
+    if message.startswith("APPROVAL"):
+        with open(approval_file, "a", encoding="utf-8") as f:
+            f.write(log_line + "\n")


### PR DESCRIPTION
## Summary
- add approvals policy for Quiver override and consensus
- implement cached is_symbol_approved with Quiver override and provider consensus
- log approval decisions to dedicated file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4ce31d10083249d20dbc15566ddca