### PR TITLE
Restore robust Quiver approvals and provider voting

### DIFF
--- a/signals/quiver_utils.py
+++ b/signals/quiver_utils.py
@@ -110,8 +110,14 @@ async def _async_is_approved_by_quiver(symbol):  # pragma: no cover - backward c
     """
 
     print(f"🔎 Checking {symbol}...", flush=True)
-    signals = await asyncio.to_thread(get_all_quiver_signals, symbol)
-    return evaluate_quiver_signals(signals, symbol)
+    try:
+        signals = await asyncio.to_thread(get_all_quiver_signals, symbol)
+        return evaluate_quiver_signals(signals, symbol)
+    except Exception as e:  # pragma: no cover - network/parse errors
+        msg = f"⛔ {symbol} no aprobado por Quiver debido a error: {e}"
+        print(msg)
+        log_event(msg)
+        return {"score": 0.0, "active_signals": []}
 
 
 def is_approved_by_quiver(symbol):  # pragma: no cover - backward compat


### PR DESCRIPTION
## Summary
- Reinstate exception handling in Quiver approval helper to return safe defaults
- Gate Quiver approvals on score and recency with resilient imports
- Prevent double counting FMP in provider consensus and add legacy macro stub

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d6b3a9a08324ba173c9641b8f8bc