### PR TITLE
Avoid blocking event loop during Quiver recency check

### DIFF
--- a/signals/reader.py
+++ b/signals/reader.py
@@ -317,7 +317,9 @@ async def _get_top_signals_async(verbose=False, exclude=None):
             async with quiver_semaphore:
                 approved = await _async_is_approved_by_quiver(symbol)
             if isinstance(approved, dict):
-                approved["fresh"] = has_recent_quiver_event(symbol, days=2)
+                approved["fresh"] = await asyncio.to_thread(
+                    has_recent_quiver_event, symbol, days=2
+                )
             quiver_approval_cache[symbol] = approved
             cond = (
                 approved


### PR DESCRIPTION
## Summary
- run `has_recent_quiver_event` in a worker thread to keep the async scanner responsive

## Testing
- `pytest tests/test_quiver_utils_no_boolean_approval.py tests/test_downtrend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5f4a3f438832489827c68346e98c5