### PR TITLE
Scale shares by market exposure factor

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -144,7 +144,11 @@ def calculate_position_size_risk_based(
             shares = math.floor(per_symbol_cap / price)
         notional = shares * price
 
-    notional *= float(market_exposure_factor or 1.0)
+    exposure = float(market_exposure_factor or 1.0)
+    shares *= exposure
+    if not r["allow_fractional"]:
+        shares = math.floor(shares)
+    notional = shares * price
 
     if notional <= 0 or shares <= 0:
         return {

--- a/tests/test_risk_sizing.py
+++ b/tests/test_risk_sizing.py
@@ -26,7 +26,7 @@ def test_caps_and_fractional_behavior():
     r2 = calculate_position_size_risk_based("CCC", price=500, atr=0.1, equity=equity, cfg=cfg2, market_exposure_factor=1.0)
     assert r2["shares"] == 0 or r2["notional"] == 0
 
-def test_exposure_factor_affects_notional():
+def test_exposure_factor_scales_shares_and_notional():
     from core.executor import calculate_position_size_risk_based
     class Cfg(dict):
         pass
@@ -35,6 +35,7 @@ def test_exposure_factor_affects_notional():
     reduced = calculate_position_size_risk_based("DDD", price=100, atr=1, equity=50000, cfg=cfg, market_exposure_factor=0.7)
     assert reduced["notional"] < base["notional"]
     assert abs(reduced["notional"]/base["notional"] - 0.7) < 1e-6
+    assert abs(reduced["shares"]/base["shares"] - 0.7) < 1e-6
 
 def test_min_stop_pct_when_atr_small():
     from core.executor import calculate_position_size_risk_based


### PR DESCRIPTION
## Summary
- Apply market exposure factor to shares in risk-based sizing and recompute notional
- Test that exposure factor scales both shares and notional

## Testing
- `pytest tests/test_risk_sizing.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb2b118aa88324811bbd390ab7e758