### PR TITLE
feat: add chandelier trailing and partial TP

### DIFF
--- a/broker/alpaca.py
+++ b/broker/alpaca.py
@@ -31,6 +31,17 @@ _price_cache = {}
 NY_TZ = timezone("America/New_York")
 
 
+def supports_bracket_trailing() -> bool:
+    """Return whether Alpaca allows trailing stops inside bracket orders."""
+    # Alpaca currently does not allow trailing stops within standard brackets.
+    return False
+
+
+def supports_fractional_shares() -> bool:
+    """Indicate if Alpaca supports fractional share trading."""
+    return True
+
+
 def _within_regular_hours(now_ny: datetime) -> bool:
     """Return True only during regular trading hours (Mon-Fri, 9:30-16:00 NY)."""
     if now_ny.weekday() >= 5:

--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -23,3 +23,11 @@ risk:
   min_trailing_pct: 0.005        # 0.5% (se usará en #6)
   max_trailing_pct: 0.05         # 5%   (se usará en #6)
   allow_fractional: true         # habilitar compra fraccional si broker lo soporta
+
+exits:
+  use_partial_take_profit: true
+  partial_tp_at_R: 1.5          # vender 1/3 a +1.5R
+  partial_tp_fraction: 0.3333    # 1/3
+  trailing_mode: "chandelier"    # único modo por ahora
+  update_trailing_on_new_highs: true
+  allow_tp_and_trailing_same_bracket: false  # si el broker no lo soporta, usa órdenes separadas

--- a/tests/test_chandelier_trail_bounds.py
+++ b/tests/test_chandelier_trail_bounds.py
@@ -1,0 +1,12 @@
+def test_chandelier_within_min_max():
+    from core.executor import compute_chandelier_trail
+
+    class Cfg(dict):
+        pass
+
+    cfg = Cfg(risk={"atr_k": 2.0, "min_trailing_pct": 0.005, "max_trailing_pct": 0.05})
+    # price=100, atr=0.1 -> atr_k*atr=0.2, min%*price=0.5 -> trail=0.5, ≤ max=5.0
+    assert abs(compute_chandelier_trail(100, 0.1, cfg) - 0.5) < 1e-6
+    # price=100, atr=5 -> atr_k*atr=10, min=0.5 -> trail=10 capped to 5
+    assert abs(compute_chandelier_trail(100, 5, cfg) - 5.0) < 1e-6
+

--- a/tests/test_do_not_lower_stop.py
+++ b/tests/test_do_not_lower_stop.py
@@ -1,0 +1,11 @@
+def test_stop_never_decreases():
+    last_high = 100.0
+    trail = 2.0
+    stop = last_high - trail  # 98
+    last_high = 103.0
+    stop_new = max(stop, last_high - trail)  # 101
+    assert stop_new >= stop
+    price = 100.0
+    stop_new2 = max(stop_new, price - trail)
+    assert stop_new2 == stop_new
+

--- a/tests/test_no_conflict_when_tp_and_trail_disallowed.py
+++ b/tests/test_no_conflict_when_tp_and_trail_disallowed.py
@@ -1,0 +1,9 @@
+def test_branch_when_broker_disallows_trailing_bracket(monkeypatch):
+    from core.executor import should_use_combined_bracket
+    import types
+
+    cfg = {"exits": {"allow_tp_and_trailing_same_bracket": True}}
+    broker_mod = types.SimpleNamespace(supports_bracket_trailing=lambda: False)
+
+    assert not should_use_combined_bracket(cfg, broker_mod)
+

--- a/tests/test_partial_tp_price.py
+++ b/tests/test_partial_tp_price.py
@@ -1,0 +1,11 @@
+def test_partial_tp_at_1p5R():
+    from core.executor import compute_partial_take_profit
+
+    class Cfg(dict):
+        pass
+
+    cfg = Cfg(exits={"use_partial_take_profit": True, "partial_tp_at_R": 1.5})
+    entry, stop_dist = 100.0, 4.0
+    tp = compute_partial_take_profit(entry, stop_dist, cfg)
+    assert abs(tp - 106.0) < 1e-6
+


### PR DESCRIPTION
## Summary
- add configurable exits section with partial TP and trailing flags
- implement chandelier-style trailing distance and partial take profit helpers
- expose broker capability flags and basic branch logic
- cover trailing/TP helpers with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc944bb8e48324bdb5731d5e7ef46d