### PR TITLE
Fix missing intraday execution tracking after fills

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -897,6 +897,14 @@ def _on_fill_success(symbol, coid, status, cfg):
     avg_price = getattr(status, "filled_avg_price", 0)
     StateManager.add_executed_symbol(symbol)
     StateManager.add_open_position(symbol, coid, filled_qty, avg_price)
+    with executed_symbols_today_lock:
+        executed_symbols_today.add(symbol)
+    mark_executed(symbol)
+    amount_usd = float(filled_qty) * float(avg_price)
+    with pending_trades_lock:
+        pending_trades.add(
+            f"{symbol}: {filled_qty} unidades — ${amount_usd:.2f}"
+        )
     log_event(f"FILL {symbol}: qty={filled_qty} avg={avg_price} coid={coid}")
 
 


### PR DESCRIPTION
## Summary
- track filled symbols in intraday sets and pending trade log
- mark symbols executed after fills to prevent retrading

## Testing
- `pytest` *(fails: Key ID must be given to access Alpaca trade API)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf9e547748324a62e6fe39b6c49ac