### PR TITLE
Fix deadlock in _on_fill_success

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -897,8 +897,7 @@ def _on_fill_success(symbol, coid, status, cfg):
     avg_price = getattr(status, "filled_avg_price", 0)
     StateManager.add_executed_symbol(symbol)
     StateManager.add_open_position(symbol, coid, filled_qty, avg_price)
-    with executed_symbols_today_lock:
-        executed_symbols_today.add(symbol)
+    executed_symbols_today.add(symbol)
     mark_executed(symbol)
     amount_usd = float(filled_qty) * float(avg_price)
     with pending_trades_lock:


### PR DESCRIPTION
## Summary
- prevent deadlock in _on_fill_success by removing redundant DailySet lock wrapping executed_symbols_today.add

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdfee291dc8324829a84df29398681