### PR TITLE
Add event-based entry filters and session cutoff

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -31,3 +31,11 @@ exits:
   trailing_mode: "chandelier"    # único modo por ahora
   update_trailing_on_new_highs: true
   allow_tp_and_trailing_same_bracket: false  # si el broker no lo soporta, usa órdenes separadas
+
+market:
+  avoid_earnings_days: 3       # ventana ±días para bloquear/reducir
+  avoid_last_minutes: 20       # no abrir nuevas posiciones a X min del cierre
+  event_block_mode: "reduce"   # "block" | "reduce"
+  event_reduce_fraction: 0.5   # si "reduce", reduce tamaño al 50%
+  consider_dividends: true
+  consider_guidance: true

--- a/tests/test_event_policies.py
+++ b/tests/test_event_policies.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta, timezone
+
+
+def test_minutes_to_close_cutoff(monkeypatch):
+    from core.executor import _apply_event_and_cutoff_policies
+    from utils import market_calendar
+
+    now = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        market_calendar, "next_session_close_utc", lambda: now + timedelta(minutes=5)
+    )
+
+    class Cfg(dict):
+        pass
+
+    cfg = Cfg(market={"avoid_last_minutes": 10})
+    ok, notional, reason = _apply_event_and_cutoff_policies("AAA", 1000.0, cfg)
+    assert ok is False and "cutoff_last_10m" in reason
+
+
+def test_event_block_and_reduce(monkeypatch):
+    from core.executor import _apply_event_and_cutoff_policies
+
+    class Cfg(dict):
+        pass
+
+    cfg_block = Cfg(
+        market={"avoid_earnings_days": 3, "event_block_mode": "block", "avoid_last_minutes": 0}
+    )
+    cfg_reduce = Cfg(
+        market={
+            "avoid_earnings_days": 3,
+            "event_block_mode": "reduce",
+            "event_reduce_fraction": 0.5,
+            "avoid_last_minutes": 0,
+        }
+    )
+
+    monkeypatch.setattr(
+        "utils.market_calendar.earnings_within", lambda symbol, days: True
+    )
+    ok, notional, reason = _apply_event_and_cutoff_policies("TEST", 1000.0, cfg_block)
+    assert ok is False and "event_block" in reason
+
+    ok, notional, reason = _apply_event_and_cutoff_policies("TEST", 1000.0, cfg_reduce)
+    assert ok is True and abs(notional - 500.0) < 1e-6
+
+
+def test_no_event_no_cutoff(monkeypatch):
+    from core.executor import _apply_event_and_cutoff_policies
+
+    class Cfg(dict):
+        pass
+
+    cfg = Cfg(market={"avoid_earnings_days": 3, "avoid_last_minutes": 0})
+    monkeypatch.setattr("utils.market_calendar.earnings_within", lambda s, d: False)
+    ok, notional, reason = _apply_event_and_cutoff_policies("TEST", 1000.0, cfg)
+    assert ok is True and abs(notional - 1000.0) < 1e-6 and reason == "ok"

--- a/utils/market_calendar.py
+++ b/utils/market_calendar.py
@@ -1,0 +1,63 @@
+import time
+from datetime import datetime, timedelta, timezone
+from signals.fmp_utils import search_stock_news
+
+# Simple in-memory cache
+_CACHE: dict[str, tuple[object, float]] = {}
+
+def _cache_get(key: str, ttl: int = 900):
+    v = _CACHE.get(key)
+    if not v:
+        return None
+    data, ts = v
+    if time.time() - ts > ttl:
+        return None
+    return data
+
+
+def _cache_put(key: str, data):
+    _CACHE[key] = (data, time.time())
+
+
+def next_session_close_utc() -> datetime:
+    """Return the next session close time in UTC.
+
+    Placeholder implementation uses 20:00 UTC (~16:00 ET) for regular NYSE
+    close without accounting for holidays or early closes.
+    """
+    today = datetime.utcnow().date()
+    return datetime(today.year, today.month, today.day, 20, 0, 0, tzinfo=timezone.utc)
+
+
+def minutes_to_close(now_utc: datetime | None = None) -> int:
+    now = now_utc or datetime.utcnow().replace(tzinfo=timezone.utc)
+    close = next_session_close_utc()
+    return max(0, int((close - now).total_seconds() // 60))
+
+
+def earnings_within(symbol: str, days: int) -> bool:
+    """Heuristic detection of earnings/guidance/dividend events within ±days.
+
+    This uses basic FMP news search for the symbol looking for keywords. If the
+    FMP plan provides an earnings or dividends calendar endpoint, that could be
+    integrated here and preferred over the news heuristic.
+    """
+    key = f"earnings:{symbol}:{days}"
+    cached = _cache_get(key)
+    if cached is not None:
+        return cached
+
+    from_date = (datetime.utcnow() - timedelta(days=days)).date().isoformat()
+    to_date = (datetime.utcnow() + timedelta(days=days)).date().isoformat()
+
+    items = search_stock_news(symbols=symbol, from_date=from_date, to_date=to_date, limit=20) or []
+    kws = ("earnings", "guidance", "EPS", "outlook", "dividend", "payout")
+    flag = False
+    for it in items:
+        title = (it.get("title") or "").lower()
+        if any(k in title for k in kws):
+            flag = True
+            break
+
+    _cache_put(key, flag)
+    return flag


### PR DESCRIPTION
## Summary
- add configurable market event and session cutoff options in policy
- implement market_calendar utilities with caching for earnings/guidance/dividend detection
- apply event/cutoff policies in executor and scheduler with logging
- add tests for cutoff and event reduction/blocking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1cf82a08832493255d534626187d