### PR TITLE
fix: exclude today from VIX percentile calculation

### DIFF
--- a/tests/test_market_regime_and_penalties.py
+++ b/tests/test_market_regime_and_penalties.py
@@ -50,3 +50,24 @@ def test_compute_vix_regime_uses_cache(monkeypatch):
     b = mr.compute_vix_regime(cfg)
     assert a["regime"] in ("normal", "elevated_vol", "high_vol")
     assert b == a
+
+
+def test_compute_vix_regime_excludes_today(monkeypatch):
+    monkeypatch.setattr(mr, "_CACHE", {})
+    monkeypatch.setattr(
+        mr,
+        "_get_recent_vix_levels",
+        lambda wins: [5, 9, 8, 7, 6, 10],
+    )
+    cfg = {
+        "market": {
+            "vix_percentile_windows": [1, 5, 20],
+            "vix_high_pct": 80,
+            "vix_elevated_pct": 60,
+        }
+    }
+    res = mr.compute_vix_regime(cfg)
+    assert res["regime"] == "normal"
+    assert res["pctiles"]["pctl_1d"] == 0.0
+    assert res["pctiles"]["pctl_5d"] == 0.0
+    assert res["pctiles"]["pctl_20d"] == 0.0

--- a/utils/market_regime.py
+++ b/utils/market_regime.py
@@ -57,7 +57,9 @@ def compute_vix_regime(cfg) -> dict:
 
     pctiles = {}
     for w in wins:
-        sample = levels[:w] if len(levels) >= w else levels
+        # Exclude today's level from the percentile sample so that
+        # windows that include ``1`` compare today against prior days.
+        sample = levels[1 : w + 1]
         pctiles[f"pctl_{w}d"] = _percentile_rank(sample, today) if sample else 0.0
 
     high_th = float(mkt.get("vix_high_pct", 80))


### PR DESCRIPTION
## Summary
- exclude current VIX level from percentile samples so window=1 doesn't always classify high volatility
- add regression test for VIX percentile calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c00f457a5083249300d65e5335703b