### PR TITLE
feat: add layered caching with score threshold

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -23,6 +23,13 @@ approvals:
     score_threshold: 8.0        # umbral de convicción Quiver (ajustable)
     require_recent_event: true  # además de score, exige evento <= recency_hours
 
+cache:
+  macro_ttl_sec: 86400        # 1 día para régimen/macro
+  lot_ttl_sec: 900            # 15 min: Reddit/Tiingo/feeds por lote
+  symbol_ttl_sec: 600         # 10 min: señales por símbolo (Quiver/FMP)
+  approval_ttl_sec: 300       # 5 min: cache de aprobación
+  score_recalc_threshold: 60  # no pedir proveedores externos si overall_score < 60
+
 risk:
   max_daily_loss_pct: 0.7        # % de equity como pérdida diaria máxima antes de parar
   max_symbol_risk_pct: 0.35      # % de equity arriesgado por operación

--- a/signals/filters.py
+++ b/signals/filters.py
@@ -364,7 +364,7 @@ def _provider_votes(symbol: str, cfg) -> Dict[str, bool]:
 
 def is_symbol_approved(symbol: str, overall_score: int, cfg) -> bool:
     """Aprobación final: override Quiver opcional o consenso 2/3."""
-    ttl = 300.0
+    ttl = float(((cfg or {}).get("cache", {}) or {}).get("approval_ttl_sec", 300.0))
     cached = _APPROVAL_CACHE.get(symbol)
     now = _now_ts()
     if cached and now - cached[1] < ttl:

--- a/tests/test_cache_layers.py
+++ b/tests/test_cache_layers.py
@@ -1,0 +1,43 @@
+import os, sys
+os.environ.setdefault("APCA_API_KEY_ID", "key")
+os.environ.setdefault("APCA_API_SECRET_KEY", "secret")
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_symbol_cache_prevents_recompute(monkeypatch):
+    from signals.quiver_utils import fetch_quiver_signals
+    calls = {"n": 0}
+
+    def fake(symbol):
+        calls["n"] += 1
+        return {"ok": True}
+
+    monkeypatch.setattr("signals.quiver_utils.get_all_quiver_signals", fake)
+    a = fetch_quiver_signals("TEST")
+    b = fetch_quiver_signals("TEST")
+    assert calls["n"] == 1
+
+
+def test_heavy_endpoint_cached(monkeypatch):
+    from signals.quiver_utils import _cached_heavy_endpoint
+    calls = {"n": 0}
+
+    def fake(url):
+        calls["n"] += 1
+        return [{"Ticker": "AAA"}]
+
+    monkeypatch.setattr("signals.quiver_utils.safe_quiver_request", fake)
+    data1 = _cached_heavy_endpoint("demo", "http://example", 99999)
+    data2 = _cached_heavy_endpoint("demo", "http://example", 99999)
+    assert calls["n"] == 1 and isinstance(data2, list)
+
+
+def test_skip_externals_when_score_low(monkeypatch):
+    from signals.reader import maybe_fetch_externals
+
+    class Cfg(dict):
+        pass
+
+    cfg = Cfg(cache={"score_recalc_threshold": 60})
+    res = maybe_fetch_externals("LOW", 55, cfg)
+    assert res is None

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -1,0 +1,28 @@
+import time
+from collections import defaultdict
+
+_store = {}
+_metrics = defaultdict(int)
+
+def get(key: str, ttl: int | float | None = None):
+    v = _store.get(key)
+    if not v:
+        _metrics["miss"] += 1
+        return None
+    data, ts = v
+    if ttl is not None and time.time() - ts > ttl:
+        _metrics["expired"] += 1
+        _store.pop(key, None)
+        return None
+    _metrics["hit"] += 1
+    return data
+
+def set(key: str, data):
+    _store[key] = (data, time.time())
+
+def stats():
+    return dict(_metrics)
+
+def reset():
+    _store.clear()
+    _metrics.clear()

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,0 +1,14 @@
+from utils.cache import stats as cache_stats, reset as cache_reset
+
+
+def cache_metrics(reset: bool = False):
+    """Return cache hit/miss/expired counts."""
+    s = cache_stats()
+    metrics = {
+        "cache_hits": s.get("hit", 0),
+        "cache_misses": s.get("miss", 0),
+        "cache_expired": s.get("expired", 0),
+    }
+    if reset:
+        cache_reset()
+    return metrics


### PR DESCRIPTION
## Summary
- add configurable cache TTLs and in-memory cache store with stats
- cache heavy Quiver endpoints and symbol-level signals
- skip external providers when preliminary score is below threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7259a85c4832495747db6705dc09b