### PR TITLE
Improve equity safeguards and symbol routing reliability

### DIFF
--- a/broker/account.py
+++ b/broker/account.py
@@ -1,0 +1,41 @@
+"""Resilient helpers for retrieving account equity with caching."""
+
+from __future__ import annotations
+
+import time
+
+from broker.alpaca import api
+from utils.logger import log_event
+
+_last_equity: float | None = None
+_last_equity_ts: float = 0.0
+
+
+def _fetch_account_equity() -> float | None:
+    try:  # pragma: no cover - network call
+        account = api.get_account()
+        value = getattr(account, "equity", None)
+        if value in (None, ""):
+            return None
+        equity = float(value)
+        return equity if equity > 0 else None
+    except Exception as exc:  # pragma: no cover - defensive
+        log_event(f"ERROR EQUITY: {exc}")
+        return None
+
+
+def get_account_equity_safe(max_age_sec: float = 86400.0) -> float:
+    """Return last known positive equity, retrying the broker if possible."""
+
+    global _last_equity, _last_equity_ts
+
+    equity = _fetch_account_equity()
+    if equity is not None and equity > 0:
+        _last_equity = equity
+        _last_equity_ts = time.time()
+        return equity
+
+    if _last_equity is not None and (time.time() - _last_equity_ts) < max_age_sec:
+        return _last_equity
+
+    return 0.0

--- a/core/crypto_worker.py
+++ b/core/crypto_worker.py
@@ -8,7 +8,7 @@ from alpaca_trade_api.rest import APIError
 from broker.alpaca import api, is_market_open
 from signals.crypto_signals import get_crypto_signals
 from utils.crypto_limit import get_crypto_limit
-from utils.logger import log_event
+from utils.logger import log_event, log_once
 
 
 # Thread-safe list of executed crypto trades for daily summaries
@@ -60,7 +60,11 @@ def crypto_worker(stop_event: threading.Event) -> None:
             # Skip if a position already exists for this symbol
             try:
                 api.get_position(symbol)
-                log_event(f"⚠️ Position already open for {symbol}, skipping")
+                log_once(
+                    f"pos_open_{symbol}",
+                    f"REPORT: ⚠️ Position already open for {symbol}, skipping",
+                    min_interval_sec=60,
+                )
                 continue
             except APIError:
                 pass

--- a/core/options_trader.py
+++ b/core/options_trader.py
@@ -1,4 +1,5 @@
 from broker.alpaca import api, get_current_price
+from broker.account import get_account_equity_safe
 from utils.logger import log_event
 from datetime import datetime
 
@@ -30,8 +31,10 @@ def get_options_log_and_reset():
 def buy_simple_call_option(symbol, strike_price, expiration_date, contracts=1):
     reset_option_investment()
     try:
-        account = api.get_account()
-        equity = float(account.equity)
+        equity = get_account_equity_safe()
+        if equity <= 0:
+            log_event('RISK: ❌ equity inválido para opciones. Se omite compra.')
+            return
         max_allowed = equity * OPTIONS_INVESTMENT_LIMIT_PCT
 
         estimated_cost = strike_price * 100 * contracts

--- a/signals/quiver_utils.py
+++ b/signals/quiver_utils.py
@@ -10,7 +10,7 @@ import math
 from dataclasses import dataclass
 from .quiver_event_loop import run_in_quiver_loop
 from dotenv import load_dotenv
-from utils.logger import log_event
+from utils.logger import log_event, log_once
 from utils.cache import get as cache_get, set as cache_set
 import config
 from datetime import datetime, timedelta, timezone
@@ -293,9 +293,17 @@ def evaluate_quiver_signals(signals, symbol=""):
 def safe_quiver_request(url, retries=5, delay=4):
     # Log only that the key is present without revealing it
     if QUIVER_API_KEY:
-        print("🔑 Usando clave Quiver: [REDACTED]")
+        log_once(
+            "quiver_api_key_present",
+            "🔑 Usando clave Quiver: [REDACTED]",
+            min_interval_sec=3600,
+        )
     else:
-        print("🔑 Advertencia: QUIVER_API_KEY no configurada")
+        log_once(
+            "quiver_api_key_missing",
+            "🔑 Advertencia: QUIVER_API_KEY no configurada",
+            min_interval_sec=3600,
+        )
     for i in range(retries):
         try:
             r = throttled_request(requests.get, url, headers=HEADERS, timeout=QUIVER_TIMEOUT)

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -7,11 +7,13 @@ import threading
 from typing import Dict
 
 from utils.cache import stats as cache_stats, reset as cache_reset
+from utils.state import StateManager
 
 __all__ = ["inc", "get_all", "cache_metrics"]
 
 _lock = threading.Lock()
 _counters: defaultdict[str, int] = defaultdict(int)
+_counters.update({k: int(v) for k, v in StateManager.get_metric_counters().items()})
 
 
 def inc(key: str, n: int = 1) -> None:
@@ -20,6 +22,7 @@ def inc(key: str, n: int = 1) -> None:
         return
     with _lock:
         _counters[key] += int(n)
+        StateManager.set_metric_counter(key, _counters[key])
 
 
 def get_all(reset: bool = False) -> Dict[str, int]:
@@ -35,6 +38,9 @@ def get_all(reset: bool = False) -> Dict[str, int]:
         snapshot = dict(_counters)
         if reset:
             _counters.clear()
+            StateManager.replace_metric_counters({})
+        else:
+            StateManager.replace_metric_counters(snapshot)
         return snapshot
 
 

--- a/utils/symbols.py
+++ b/utils/symbols.py
@@ -1,0 +1,38 @@
+"""Helpers for routing symbols by asset class and normalizing tickers."""
+
+from __future__ import annotations
+
+CRYPTO_SUFFIXES = ("USD", "USDT", "USDC")
+
+
+def detect_asset_class(symbol: str) -> str:
+    """Return an asset class identifier for ``symbol``.
+
+    Asset classes currently recognized: ``equity``, ``crypto`` and ``preferred``.
+    """
+
+    if not symbol:
+        return "equity"
+    s = symbol.upper()
+    if any(s.endswith(suf) for suf in CRYPTO_SUFFIXES):
+        return "crypto"
+    if ".PR" in s or ".PRA" in s or ".PRB" in s or ".PRC" in s:
+        return "preferred"
+    if "." in s:
+        parts = s.split(".")
+        if parts[-1].startswith("PR"):
+            return "preferred"
+    return "equity"
+
+
+def normalize_for_yahoo(symbol: str) -> str:
+    """Return a Yahoo Finance compatible ticker for ``symbol``."""
+
+    if not symbol:
+        return symbol
+    s = symbol.upper()
+    if ".PR" in s:
+        base, pr = s.split(".PR", 1)
+        if pr:
+            return f"{base}-P{pr[0]}"
+    return s


### PR DESCRIPTION
## Summary
- add a broker/account helper to cache equity values and integrate equity guards in schedulers, async execution, and options trading
- harden trailing-stop monitoring with safe numeric handling and asset-class-aware fallbacks
- introduce symbol routing utilities to skip unsupported assets in scoring, gates, and backtesting while persisting metrics and rate-limiting noisy logs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb2788e7088324ade65cac9c4cade3