### PR TITLE
Stop caching stale equity after zero balance

### DIFF
--- a/broker/account.py
+++ b/broker/account.py
@@ -17,8 +17,7 @@ def _fetch_account_equity() -> float | None:
         value = getattr(account, "equity", None)
         if value in (None, ""):
             return None
-        equity = float(value)
-        return equity if equity > 0 else None
+        return float(value)
     except Exception as exc:  # pragma: no cover - defensive
         log_event(f"ERROR EQUITY: {exc}")
         return None
@@ -30,10 +29,14 @@ def get_account_equity_safe(max_age_sec: float = 86400.0) -> float:
     global _last_equity, _last_equity_ts
 
     equity = _fetch_account_equity()
-    if equity is not None and equity > 0:
-        _last_equity = equity
-        _last_equity_ts = time.time()
-        return equity
+    if equity is not None:
+        if equity > 0:
+            _last_equity = equity
+            _last_equity_ts = time.time()
+            return equity
+        _last_equity = None
+        _last_equity_ts = 0.0
+        return 0.0
 
     if _last_equity is not None and (time.time() - _last_equity_ts) < max_age_sec:
         return _last_equity


### PR DESCRIPTION
## Summary
- treat broker equity readings of zero or less as valid responses instead of cache misses
- clear the cached equity and return 0 when a fresh non-positive balance is received

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb2f4ef08c8324ae539b82a79ca4f8