### PR TITLE
Implement tick rounding and monitoring guards

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -3,6 +3,10 @@ gate:
   min_cap: 500e6
   min_avg_vol_20d: 500000
   strong_signal_max_age_days: 3
+  exclude_regex:
+    - "\\.[Pp][Rr][A-Za-z]"
+    - "(^|\\.)WLACU$|U$|\\-U$"
+    - "W$|WS$|WSA$|WT$"
 
 score:
   strong_recency_hours: 48
@@ -28,7 +32,9 @@ cache:
   lot_ttl_sec: 900            # 15 min: Reddit/Tiingo/feeds por lote
   symbol_ttl_sec: 600         # 10 min: señales por símbolo (Quiver/FMP)
   approval_ttl_sec: 300       # 5 min: cache de aprobación
-  score_recalc_threshold: 60  # no pedir proveedores externos si overall_score < 60
+  quiver_heavy_ttl_sec: 480   # 8 minutos para endpoints pesados
+  quiver_concurrency: 2
+  score_recalc_threshold: 50  # no pedir proveedores externos si overall_score < 50
 
 risk:
   max_daily_loss_pct: 0.7        # % de equity como pérdida diaria máxima antes de parar
@@ -38,6 +44,10 @@ risk:
   min_trailing_pct: 0.005        # 0.5% (se usará en #6)
   max_trailing_pct: 0.05         # 5%   (se usará en #6)
   allow_fractional: true         # habilitar compra fraccional si broker lo soporta
+  enforce_tick_rounding: true
+  min_tick_equity_ge_1: 0.01
+  min_tick_equity_lt_1: 0.0001
+  min_tick_crypto: 0.01
 
 exits:
   use_partial_take_profit: true
@@ -71,3 +81,6 @@ reporting:
   include_cache_metrics: true
   include_risk_metrics: true
   funnel_fields: [scanned, gated, scored, approved, ordered, rejected]
+
+shorts:
+  enabled: false

--- a/core/broker.py
+++ b/core/broker.py
@@ -1,0 +1,53 @@
+"""Broker-related helpers for price precision handling."""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import config
+
+TICK_DEFAULTS = {
+    "equity_ge_1": 0.01,
+    "equity_lt_1": 0.0001,
+    "etf": 0.01,
+    "option": 0.01,
+    "crypto": 0.01,
+}
+
+
+def _policy_ticks() -> dict[str, float]:
+    risk_cfg = getattr(config, "_policy", {}).get("risk", {}) if getattr(config, "_policy", None) else {}
+    return {
+        "equity_ge_1": float(risk_cfg.get("min_tick_equity_ge_1", TICK_DEFAULTS["equity_ge_1"])),
+        "equity_lt_1": float(risk_cfg.get("min_tick_equity_lt_1", TICK_DEFAULTS["equity_lt_1"])),
+        "etf": float(risk_cfg.get("min_tick_etf", TICK_DEFAULTS["etf"])),
+        "option": float(risk_cfg.get("min_tick_option", TICK_DEFAULTS["option"])),
+        "crypto": float(risk_cfg.get("min_tick_crypto", TICK_DEFAULTS["crypto"])),
+    }
+
+
+def get_tick_size(symbol: str, asset_class: Optional[str], price: Optional[float]) -> float:
+    """Return the tick size to use for ``symbol`` at ``price``."""
+
+    ticks = _policy_ticks()
+    if (asset_class or "").lower() == "crypto":
+        return ticks["crypto"]
+    if price is None:
+        return ticks["equity_ge_1"]
+    if price < 1.0:
+        return ticks["equity_lt_1"]
+    return ticks["equity_ge_1"]
+
+
+def round_to_tick(price: Optional[float], tick: Optional[float], mode: str = "nearest") -> Optional[float]:
+    """Round ``price`` to the nearest valid ``tick`` according to ``mode``."""
+
+    if price is None or tick is None or tick <= 0:
+        return price
+    if mode == "down":
+        return math.floor(price / tick) * tick
+    if mode == "up":
+        return math.ceil(price / tick) * tick
+    return round(price / tick) * tick
+

--- a/core/crypto_worker.py
+++ b/core/crypto_worker.py
@@ -8,7 +8,7 @@ from alpaca_trade_api.rest import APIError
 from broker.alpaca import api, is_market_open
 from signals.crypto_signals import get_crypto_signals
 from utils.crypto_limit import get_crypto_limit
-from utils.logger import log_event, log_once
+from utils.logger import log_event
 
 
 # Thread-safe list of executed crypto trades for daily summaries
@@ -60,10 +60,12 @@ def crypto_worker(stop_event: threading.Event) -> None:
             # Skip if a position already exists for this symbol
             try:
                 api.get_position(symbol)
-                log_once(
-                    f"pos_open_{symbol}",
-                    f"REPORT: ⚠️ Position already open for {symbol}, skipping",
-                    min_interval_sec=60,
+                log_event(
+                    f"Position already open for {symbol}, skipping",
+                    event="DEBUG",
+                    symbol=symbol,
+                    dedupe_key=("open_position", symbol),
+                    dedupe_ttl=45,
                 )
                 continue
             except APIError:

--- a/tests/test_broker_ticks.py
+++ b/tests/test_broker_ticks.py
@@ -1,0 +1,45 @@
+import importlib
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("APCA_API_KEY_ID", "test")
+os.environ.setdefault("APCA_API_SECRET_KEY", "test")
+
+from core.broker import round_to_tick
+from core import executor
+
+
+def test_round_to_tick_modes():
+    assert round_to_tick(70.3266, 0.01, mode="up") == pytest.approx(70.33)
+    assert round_to_tick(70.3266, 0.01, mode="down") == pytest.approx(70.32)
+
+
+def test_apply_tick_rounding_long(monkeypatch):
+    # Ensure we use the latest policy configuration
+    import config
+
+    importlib.reload(config)
+    tick, stop, take_profit, trail = executor._apply_tick_rounding(
+        symbol="TEST",
+        side="buy",
+        entry_price=10.15,
+        asset_class="equity",
+        stop_price=10.049,
+        take_profit=10.512,
+        trail_price=0.127,
+        cfg=config._policy,
+    )
+    assert tick == pytest.approx(0.01)
+    assert stop == pytest.approx(round_to_tick(10.049, tick, mode="down"))
+    assert take_profit == pytest.approx(round_to_tick(10.512, tick, mode="up"))
+    assert trail == pytest.approx(round_to_tick(0.127, tick))
+
+
+def test_partial_take_profit_respects_tick():
+    result = executor.compute_partial_take_profit(10.0, 0.5, cfg={}, tick=0.01)
+    expected = round_to_tick(10.0 + 1.5 * 0.5, 0.01, mode="up")
+    assert result == pytest.approx(expected)

--- a/tests/test_monitor_guards.py
+++ b/tests/test_monitor_guards.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("APCA_API_KEY_ID", "test")
+os.environ.setdefault("APCA_API_SECRET_KEY", "test")
+
+from core import monitor
+
+
+def test_monitor_guard_skips_invalid_inputs(monkeypatch):
+    events = []
+    monkeypatch.setattr(monitor, "log_event", lambda message, **_: events.append(message))
+    monkeypatch.setattr(monitor, "get_current_price", lambda symbol: 1.0)
+
+    monitor.check_virtual_take_profit_and_stop(
+        symbol="XYZ",
+        entry_price=None,
+        qty=0,
+        qty_available=0,
+        position_side="long",
+        asset_class="us_equity",
+    )
+
+    assert any("skip" in msg for msg in events)

--- a/tests/test_universe_filter.py
+++ b/tests/test_universe_filter.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("APCA_API_KEY_ID", "test")
+os.environ.setdefault("APCA_API_SECRET_KEY", "test")
+
+from signals.reader import is_symbol_excluded
+
+
+def test_universe_exclusion_patterns():
+    symbols = ["HFRO.PRA", "WLACU", "XYZW", "NE.WSA"]
+    for symbol in symbols:
+        assert is_symbol_excluded(symbol)


### PR DESCRIPTION
## Summary
- add broker-level helpers to determine tick sizes and enforce rounding on stops, take-profits and trailing orders across executors and monitors
- harden monitor logic with protective guards against missing pricing data while rounding watchdog stops to valid ticks and deduplicating noisy logs
- improve symbol hygiene, quiver cache throttling, and configuration defaults while covering changes with new regression tests

## Testing
- pytest tests/test_broker_ticks.py tests/test_monitor_guards.py tests/test_universe_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68cc79c050a883249cd8ff53c3525c1a