### PR TITLE
Fix approvals logger directory handling

### DIFF
--- a/libs/logging/approvals.py
+++ b/libs/logging/approvals.py
@@ -3,6 +3,26 @@ import logging
 import os
 from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
+from typing import Optional
+
+
+def _resolve_log_dir() -> Optional[str]:
+    candidates = [
+        os.getenv("LOG_DIR"),
+        "/var/data/logs",
+        "/tmp/logs",
+        "./logs",
+    ]
+    for cand in candidates:
+        if not cand:
+            continue
+        try:
+            os.makedirs(cand, exist_ok=True)
+        except Exception:
+            continue
+        else:
+            return cand
+    return None
 
 
 def _mk_logger():
@@ -10,23 +30,55 @@ def _mk_logger():
     if logger.handlers:
         return logger
 
-    log_dir = os.getenv("LOG_DIR", "/data/logs")
-    os.makedirs(log_dir, exist_ok=True)
-
-    file_handler = RotatingFileHandler(
-        os.path.join(log_dir, "approvals.log"),
-        maxBytes=5_000_000,
-        backupCount=5,
-        encoding="utf-8",
-    )
-    file_handler.setLevel(logging.INFO)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
 
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(logging.INFO)
-
-    logger.setLevel(logging.INFO)
-    logger.addHandler(file_handler)
     logger.addHandler(stream_handler)
+
+    log_dir = _resolve_log_dir()
+    log_event = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "component": "approvals_logger",
+    }
+
+    if log_dir:
+        log_path = os.path.join(log_dir, "approvals.log")
+        try:
+            file_handler = RotatingFileHandler(
+                log_path,
+                maxBytes=5_000_000,
+                backupCount=5,
+                encoding="utf-8",
+            )
+            file_handler.setLevel(logging.INFO)
+            logger.addHandler(file_handler)
+            log_event.update(
+                {
+                    "event": "file_handler_ready",
+                    "path": log_path,
+                }
+            )
+            logger.info(json.dumps(log_event, ensure_ascii=False))
+        except Exception as exc:
+            log_event.update(
+                {
+                    "event": "console_only",
+                    "reason": str(exc),
+                }
+            )
+            logger.warning(json.dumps(log_event, ensure_ascii=False))
+    else:
+        log_event.update(
+            {
+                "event": "console_only",
+                "reason": "no_writable_directory",
+                "hint": "set LOG_DIR or mount /var/data",
+            }
+        )
+        logger.warning(json.dumps(log_event, ensure_ascii=False))
+
     return logger
 
 


### PR DESCRIPTION
## Summary
- resolve a writable log directory for approvals logging with fallback to console-only mode
- initialize rotating file and console handlers without duplication and emit startup status events
- ensure approvals events are logged as JSON with UTC timestamps regardless of handler availability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1c726ac548324aebd0883ed60cef0