### PR TITLE
Implement bracket order workflow with reconciliation logging

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -20,6 +20,7 @@ from core.executor import (
     _apply_event_and_cutoff_policies,
     _cfg_risk,
     _equity_guard,
+    log_audit_snapshot,
 )
 import config
 
@@ -34,6 +35,7 @@ from utils.state import StateManager
 from utils.emailer import send_email
 from utils.backtest_report import generate_paper_summary, analyze_trades, format_summary
 from utils.logger import log_event, log_dir
+from utils.system_log import get_logger
 from utils.telegram_report import generate_cumulative_report
 from utils.telegram_alert import send_telegram_alert
 from utils import report_builder
@@ -65,6 +67,8 @@ from utils.crypto_limit import get_crypto_limit
 
 summary_lock = threading.Lock()
 _last_summary_date = None
+
+sched_log = get_logger("core.scheduler")
 
 
 def reconcile_on_boot() -> None:
@@ -238,6 +242,7 @@ def pre_market_scan():
         else:
             print("🔍 Sin oportunidades válidas en este ciclo.", flush=True)
 
+        log_audit_snapshot(api, sched_log)
         pytime.sleep(1)  # Espera mínima para no saturar el sistema
 
 

--- a/tests/test_atomic_state_update_on_fill.py
+++ b/tests/test_atomic_state_update_on_fill.py
@@ -20,6 +20,12 @@ def test_atomic_state_update_on_fill(monkeypatch):
     monkeypatch.setattr(executor.broker, "submit_order", fake_submit_order)
     monkeypatch.setattr(executor, "_wait_for_fill_or_timeout", fake_wait)
     monkeypatch.setattr(executor, "log_event", lambda *a, **k: None)
+    monkeypatch.setattr(executor, "reconcile_after_fill", lambda *a, **k: None)
+    monkeypatch.setattr(executor.api, "get_position", lambda symbol: types.SimpleNamespace(qty=0), raising=False)
+    monkeypatch.setattr(executor, "get_current_price", lambda symbol: 100)
+    monkeypatch.setattr(executor.broker, "list_open_orders_today", lambda: [])
+    executor._recent_intents.clear()
+    executor._intent_by_coid.clear()
 
     res = executor.place_order_with_trailing_stop("AAPL", "buy", 5, "market", None, {})
     assert res is True

--- a/tests/test_idempotent_submit_by_client_id.py
+++ b/tests/test_idempotent_submit_by_client_id.py
@@ -7,12 +7,10 @@ from utils.state import StateManager
 def test_idempotent_submit_by_client_id(monkeypatch):
     StateManager.clear()
 
-    exists_calls = iter([False, True])
     submit_called = []
-    reconcile_called = []
 
     def fake_order_exists(client_order_id):
-        return next(exists_calls)
+        return False
 
     def fake_submit_order(**kwargs):
         submit_called.append(kwargs)
@@ -22,18 +20,20 @@ def test_idempotent_submit_by_client_id(monkeypatch):
     def fake_wait(coid, timeout_sec):
         return types.SimpleNamespace(state="filled", filled_qty=1, filled_avg_price=10)
 
-    def fake_reconcile(symbol, coid, cfg):
-        reconcile_called.append((symbol, coid))
-        return True
-
     monkeypatch.setattr(executor.broker, "order_exists", fake_order_exists)
     monkeypatch.setattr(executor.broker, "submit_order", fake_submit_order)
     monkeypatch.setattr(executor, "_wait_for_fill_or_timeout", fake_wait)
-    monkeypatch.setattr(executor, "_reconcile_existing_order", fake_reconcile)
     monkeypatch.setattr(executor, "log_event", lambda *a, **k: None)
+    monkeypatch.setattr(executor, "reconcile_after_fill", lambda *a, **k: None)
+    monkeypatch.setattr(executor.api, "get_position", lambda symbol: types.SimpleNamespace(qty=0), raising=False)
+    monkeypatch.setattr(executor, "get_current_price", lambda symbol: 100)
+    monkeypatch.setattr(executor.broker, "list_open_orders_today", lambda: [])
+    executor._recent_intents.clear()
+    executor._intent_by_coid.clear()
 
-    executor.place_order_with_trailing_stop("AAPL", "buy", 1, "market", None, {})
-    executor.place_order_with_trailing_stop("AAPL", "buy", 1, "market", None, {})
+    res1 = executor.place_order_with_trailing_stop("AAPL", "buy", 1, "market", None, {})
+    res2 = executor.place_order_with_trailing_stop("AAPL", "buy", 1, "market", None, {})
 
+    assert res1 is True
+    assert res2 is False
     assert len(submit_called) == 1
-    assert len(reconcile_called) == 1

--- a/tests/test_no_duplicate_orders_with_lock.py
+++ b/tests/test_no_duplicate_orders_with_lock.py
@@ -27,6 +27,12 @@ def test_no_duplicate_orders_with_lock(monkeypatch):
     monkeypatch.setattr(executor.broker, "submit_order", fake_submit_order)
     monkeypatch.setattr(executor, "_wait_for_fill_or_timeout", fake_wait)
     monkeypatch.setattr(executor, "log_event", lambda *a, **k: None)
+    monkeypatch.setattr(executor, "reconcile_after_fill", lambda *a, **k: None)
+    monkeypatch.setattr(executor.api, "get_position", lambda symbol: types.SimpleNamespace(qty=0), raising=False)
+    monkeypatch.setattr(executor, "get_current_price", lambda symbol: 100)
+    monkeypatch.setattr(executor.broker, "list_open_orders_today", lambda: [])
+    executor._recent_intents.clear()
+    executor._intent_by_coid.clear()
 
     t = threading.Thread(
         target=executor.place_order_with_trailing_stop,

--- a/tests/test_timeout_then_pending.py
+++ b/tests/test_timeout_then_pending.py
@@ -7,10 +7,13 @@ from utils.state import StateManager
 def test_timeout_then_pending(monkeypatch):
     StateManager.clear()
 
+    submitted = {}
+
     def fake_order_exists(client_order_id):
         return False
 
     def fake_submit_order(**kwargs):
+        submitted["coid"] = kwargs.get("client_order_id")
         return True, "1"
 
     def fake_wait(coid, timeout_sec):
@@ -20,9 +23,14 @@ def test_timeout_then_pending(monkeypatch):
     monkeypatch.setattr(executor.broker, "submit_order", fake_submit_order)
     monkeypatch.setattr(executor, "_wait_for_fill_or_timeout", fake_wait)
     monkeypatch.setattr(executor, "log_event", lambda *a, **k: None)
+    monkeypatch.setattr(executor.api, "get_position", lambda symbol: types.SimpleNamespace(qty=0), raising=False)
+    monkeypatch.setattr(executor, "get_current_price", lambda symbol: 100)
+    monkeypatch.setattr(executor.broker, "list_open_orders_today", lambda: [])
+    executor._recent_intents.clear()
+    executor._intent_by_coid.clear()
 
     res = executor.place_order_with_trailing_stop("AAPL", "buy", 1, "market", None, {})
     assert res is True
-    assert StateManager.get_open_orders() == {"AAPL": executor.make_client_order_id("AAPL", "buy")}
+    assert StateManager.get_open_orders() == {"AAPL": submitted.get("coid")}
     assert StateManager.get_open_positions() == {}
     assert StateManager.get_executed_symbols() == set()

--- a/utils/system_log.py
+++ b/utils/system_log.py
@@ -1,0 +1,30 @@
+"""Shared logging configuration for the trading bot."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+
+_DEFAULT_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a configured :class:`logging.Logger` instance.
+
+    The logger writes to stdout with a compact timestamped formatter.  The
+    configuration is applied only once per logger to avoid duplicate handlers.
+    """
+
+    logger = logging.getLogger(name if name else "trading")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            fmt="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt=_DEFAULT_FMT,
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+    return logger


### PR DESCRIPTION
## Summary
- add a shared system logger and log Alpaca environment details at startup
- introduce reconcile_after_fill with audit timeline logging and call it from order fill paths
- enforce bracket-based long entries with duplicate intent protection, rounded stops, and audit snapshots
- extend tests to stub Alpaca access and validate the new duplicate handling behavior

## Testing
- APCA_API_KEY_ID=dummy APCA_API_SECRET_KEY=dummy PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d52295519483249ae919b15ff684ba