### PR TITLE
fix(render): correct service type to worker and region to frankfurt

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,8 @@
 services:
-  - type: web
+  - type: worker
     name: Trading-bot
     runtime: python
-    region: oregon
+    region: frankfurt
     plan: starter
 
     # CRITICAL: This bot is stateful. Multiple instances cause:
@@ -13,17 +13,13 @@ services:
     numInstances: 1
 
     buildCommand: pip install -r requirements.txt
-    startCommand: uvicorn start:app --host 0.0.0.0 --port 10000
+    startCommand: uvicorn start:app --host 0.0.0.0 --workers 1
 
     envVars:
       - key: WEB_CONCURRENCY
         value: "1"
-      - key: PYTHON_VERSION
-        value: "3.11.0"
 
     disk:
       name: trading-data
       mountPath: /opt/render/project/src/data
       sizeGB: 1
-
-    healthCheckPath: /


### PR DESCRIPTION
- type: web → worker (background worker, not HTTP service)
- region: oregon → frankfurt (matches actual deployed service)
- Remove --port 10000 from startCommand (not needed for workers)
- Remove healthCheckPath (invalid for worker type)
- Remove PYTHON_VERSION env var (unnecessary)

Without these fixes Render ignored the render.yaml entirely, leaving autoscaling min=2 active and 2 instances competing.

https://claude.ai/code/session_01Y5XSkutcxvBkMDdupJfPGU